### PR TITLE
Move S4 function and dependencies into this repo

### DIFF
--- a/include/aor.h
+++ b/include/aor.h
@@ -1,0 +1,357 @@
+/**
+ * @file aor.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef AOR_H__
+#define AOR_H__
+
+#include <string>
+#include <list>
+#include <map>
+#include <stdio.h>
+#include <stdlib.h>
+#include "rapidjson/writer.h"
+#include "rapidjson/document.h"
+#include "associated_uris.h"
+
+/// JSON serialization constants.
+/// These live here, as the core logic of serialization lives in the AoR
+/// to_json methods, but the SDM also uses some of them.
+static const char* const JSON_BINDINGS = "bindings";
+static const char* const JSON_CID = "cid";
+static const char* const JSON_CSEQ = "cseq";
+static const char* const JSON_EXPIRES = "expires";
+static const char* const JSON_PRIORITY = "priority";
+static const char* const JSON_PARAMS = "params";
+static const char* const JSON_PATHS = "paths"; // Depracated as of PC release 119. SDM-REFACTOR-TODO: No longer needed. Delete.
+static const char* const JSON_PATH_HEADERS = "path_headers";
+static const char* const JSON_TIMER_ID = "timer_id";
+static const char* const JSON_PRIVATE_ID = "private_id";
+static const char* const JSON_EMERGENCY_REG = "emergency_reg";
+static const char* const JSON_SUBSCRIPTIONS = "subscriptions";
+static const char* const JSON_REQ_URI = "req_uri";
+static const char* const JSON_FROM_URI = "from_uri";
+static const char* const JSON_FROM_TAG = "from_tag";
+static const char* const JSON_TO_URI = "to_uri";
+static const char* const JSON_TO_TAG = "to_tag";
+static const char* const JSON_ROUTES = "routes";
+static const char* const JSON_NOTIFY_CSEQ = "notify_cseq";
+static const char* const JSON_SCSCF_URI = "scscf-uri";
+
+/// @class Binding
+///
+/// A single registered address.
+class Binding
+{
+public:
+  Binding(std::string address_of_record): _address_of_record(address_of_record) {};
+
+  /// The address of record, e.g. "sip:name@example.com".
+  std::string _address_of_record;
+
+  /// The registered contact URI, e.g.,
+  /// "sip:2125551212@192.168.0.1:55491;transport=TCP;rinstance=fad34fbcdea6a931"
+  std::string _uri;
+
+  /// The Call-ID: of the registration.  Per RFC3261, this is the same for
+  /// all registrations from a given UAC to this registrar (for this AoR).
+  /// E.g., "gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq"
+  std::string _cid;
+
+  /// Contains any path headers (in order) that were present on the
+  /// register.  Empty if there were none. This is the full path header,
+  /// including the disply name, URI and any header parameters.
+  std::list<std::string> _path_headers;
+
+  /// Contains the URI part of any path headers (in order) that were
+  /// present on the register. Empty if there were none.
+  std::list<std::string> _path_uris;
+
+  /// The CSeq value of the REGISTER request.
+  int _cseq;
+
+  /// The time (in seconds since the epoch) at which this binding should
+  /// expire.  Based on the expires parameter of the Contact: header.
+  int _expires;
+
+  /// The Contact: header q parameter (qvalue), times 1000.  This is used
+  /// to prioritise the registrations (highest value first), per RFC3261
+  /// s10.2.1.2.
+  int _priority;
+
+  /// Any other parameters found in the Contact: header, stored as key ->
+  /// value.  E.g., "+sip.ice" -> "".
+  std::map<std::string, std::string> _params;
+
+  /// The private ID this binding was registered with.
+  std::string _private_id;
+
+  /// Whether this is an emergency registration.
+  bool _emergency_registration;
+
+  /// Serialize the binding as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+  // Deserialize a binding from a JSON object.
+  //
+  // @param b_obj - The binding as a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& b_obj);
+};
+
+/// @class Subscription
+///
+/// Represents a subscription to registration events for the AoR.
+class Subscription
+{
+public:
+  Subscription(): _refreshed(false) {};
+
+  /// The Contact URI for the subscription dialog (used as the Request URI
+  /// of the NOTIFY)
+  std::string _req_uri;
+
+  /// The From URI for the subscription dialog (used in the to header of
+  /// the NOTIFY)
+  std::string _from_uri;
+
+  /// The From tag for the subscription dialog.
+  std::string _from_tag;
+
+  /// The To URI for the subscription dialog.
+  std::string _to_uri;
+
+  /// The To tag for the subscription dialog.
+  std::string _to_tag;
+
+  /// The call ID for the subscription dialog.
+  std::string _cid;
+
+  /// Whether the subscription has been refreshed since the last NOTIFY.
+  bool _refreshed;
+
+  /// The list of Record Route URIs from the subscription dialog.
+  std::list<std::string> _route_uris;
+
+  /// The time (in seconds since the epoch) at which this subscription
+  /// should expire.
+  int _expires;
+
+  /// Serialize the subscription as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+  // Deserialize a subscription from a JSON object.
+  //
+  // @param s_obj - The subscription as a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& s_obj);
+};
+
+// SDM-REFACTOR-TODO: prototype
+struct PatchObject
+{
+  PatchObject() : _increment(false) {}
+
+  std::vector<Binding> _bindings_to_update;
+  std::vector<std::string> _bindings_to_remove;
+  Subscription _subscription_to_update;
+  std::string _subscription_to_remove;
+  AssociatedURIs _associated_uris;
+  int _min_cseq;
+  bool _increment;
+};
+
+/// @class AoR
+///
+/// Addresses that are registered for this address of record.
+class AoR
+{
+public:
+  /// Default Constructor.
+  AoR(std::string sip_uri);
+
+  /// Destructor.
+  ~AoR();
+
+  /// Make sure copy is deep!
+  AoR(const AoR& other);
+
+  // Make sure assignment is deep!
+  AoR& operator= (AoR const& other);
+
+  // Common code between copy and assignment
+  void common_constructor(const AoR& other);
+
+  /// Clear all the bindings and subscriptions from this object.
+  void clear(bool clear_emergency_bindings);
+
+  /// Retrieve a binding by Binding ID, creating an empty one if necessary.
+  /// The created binding is completely empty, even the Contact URI field.
+  Binding* get_binding(const std::string& binding_id);
+
+  /// Removes any binding that had the given ID.  If there is no such binding,
+  /// does nothing.
+  void remove_binding(const std::string& binding_id);
+
+  /// Retrieve a subscription by To tag, creating an empty one if necessary.
+  Subscription* get_subscription(const std::string& to_tag);
+
+  /// Remove a subscription for the specified To tag.  If there is no
+  /// corresponding subscription does nothing.
+  void remove_subscription(const std::string& to_tag);
+
+  // Remove the bindings from an AOR object
+  void clear_bindings();
+
+  /// Binding ID -> Binding.  First is sometimes the contact URI, but not always.
+  /// Second is a pointer to an object owned by this object.
+  typedef std::map<std::string, Binding*> Bindings;
+
+  /// To tag -> Subscription.
+  typedef std::map<std::string, Subscription*> Subscriptions;
+
+  /// Retrieve all the bindings.
+  inline const Bindings& bindings() const { return _bindings; }
+
+  /// Retrieve all the subscriptions.
+  inline const Subscriptions& subscriptions() const { return _subscriptions; }
+
+  // Return the number of bindings in the AoR.
+  inline uint32_t get_bindings_count() const { return _bindings.size(); }
+
+  // Return the number of subscriptions in the AoR.
+  inline uint32_t get_subscriptions_count() const { return _subscriptions.size(); }
+
+  // Return the expiry time of the binding or subscription due to expire next.
+  int get_next_expires();
+
+  /// Copy all site agnostic values from one AoR to this AoR. This copies basically
+  /// everything, but importantly not the CAS. It doesn't remove any bindings
+  /// or subscriptions that may have been in the existing AoR but not in the copied
+  /// AoR.
+  ///
+  /// @param source_aor           Source AoR for the copy
+  void copy_aor(AoR* source_aor);
+
+  // SDM-REFACTOR-TODO: Implement/comment/test
+  int get_expiry() { return 1; }
+  void patch_aor(PatchObject* po) {};
+  void convert_aor_to_patch(PatchObject* po) {};
+  void convert_patch_to_aor(PatchObject* po) {};
+
+  /// CSeq value for event notifications for this AoR.  This is initialised
+  /// to one when the AoR record is first set up and incremented every time
+  /// the record is updated while there are active subscriptions.  (It is
+  /// sufficient to use the same CSeq for each NOTIFY sent on each active
+  /// because there is no requirement that the first NOTIFY in a dialog has
+  /// CSeq=1, and once a subscription dialog is established it should
+  /// receive every NOTIFY for the AoR.)
+  int _notify_cseq;
+
+  // Chronos Timer ID
+  std::string _timer_id;
+
+  /// S-CSCF URI name for this AoR. This is used on the SAR if the
+  /// registration expires. This field should not be changed once the
+  /// registration has been created.
+  std::string _scscf_uri;
+
+  /// Map holding the bindings for a particular AoR indexed by binding ID.
+  Bindings _bindings;
+
+  /// Map holding the subscriptions for this AoR, indexed by the To tag
+  /// generated when the subscription dialog was established.
+  Subscriptions _subscriptions;
+
+  // Associated URIs class, to hold the associated URIs for this IRS.
+  AssociatedURIs _associated_uris;
+
+  /// CAS value for this AoR record.  Used when updating an existing record.
+  /// Zero for a new record that has not yet been written to a store.
+  uint64_t _cas;
+
+  // SIP URI for this AoR
+  std::string _uri;
+
+  /// Store code is allowed to manipulate bindings and subscriptions directly.
+  friend class AoRStore;
+  friend class SubscriberDataManager;
+};
+
+/// @class AoRPair
+///
+/// Class to hold a pair of AoRs. The original AoR holds the AoR retrieved
+/// from the store, the current AoR holds any changes made to the AoR before
+/// it's put back in the store
+class AoRPair
+{
+public:
+  AoRPair(std::string aor_id)
+  {
+    _orig_aor = new AoR(aor_id);
+    _current_aor = new AoR(aor_id);
+  }
+
+  AoRPair(AoR* orig_aor, AoR* current_aor):
+    _orig_aor(orig_aor),
+    _current_aor(current_aor)
+  {}
+
+  ~AoRPair()
+  {
+    delete _orig_aor; _orig_aor = NULL;
+    delete _current_aor; _current_aor = NULL;
+  }
+
+  /// Get the current AoR
+  AoR* get_current() { return _current_aor; }
+
+  /// Does the current AoR contain any bindings?
+  bool current_contains_bindings()
+  {
+    return ((_current_aor != NULL) &&
+            (!_current_aor->_bindings.empty()));
+  }
+
+  /// Does the current AoR contain any subscriptions?
+  bool current_contains_subscriptions()
+  {
+    return ((_current_aor != NULL) &&
+            (!_current_aor->subscriptions().empty()));
+  }
+
+  /// Utility functions to compare Bindings and Subscriptions in the original AoR
+  /// and current AoR, and return the set of those created/updated or removed.
+  AoR::Bindings get_updated_bindings();
+  AoR::Subscriptions get_updated_subscriptions();
+  AoR::Bindings get_removed_bindings();
+  AoR::Subscriptions get_removed_subscriptions();
+
+private:
+  AoR* _orig_aor;
+  AoR* _current_aor;
+
+  /// Get the original AoR
+  AoR* get_orig() { return _orig_aor; }
+
+  /// The subscriber data manager is allowed to access the original AoR
+  friend class SubscriberDataManager;
+};
+
+#endif

--- a/include/aor_store.h
+++ b/include/aor_store.h
@@ -1,0 +1,62 @@
+/**
+ * @file aor_store.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef AOR_STORE_H__
+#define AOR_STORE_H__
+
+
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#include "store.h"
+#include "aor.h"
+
+// Pure virtual parent class for implementations of the AoRStore, for use
+// in the SubscriberDataManager. Defines the public interface that must
+// be implemented in any derived classes.
+class AoRStore
+{
+public:
+  /// AoRSore constructor.
+  AoRStore(){}
+
+  /// Destructor.
+  virtual ~AoRStore(){}
+
+  // Called through to from handlers code.
+  virtual bool has_servers() = 0;
+
+  /// Get the data for a particular address of record (registered SIP URI,
+  /// in format "sip:2125551212@example.com"), creating it if necessary.
+  /// May return NULL in case of error.  Result is owned
+  /// by caller and must be freed with delete.
+  ///
+  /// @param aor_id    The AoR to retrieve
+  /// @param trail     SAS trail
+  virtual AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail) = 0;
+
+  /// Update the data for a particular address of record.
+  /// if the update succeeds, this returns true.
+  ///
+  /// @param aor_id               The AoR ID to set
+  /// @param aor_pair             The AoR pair to set data from
+  /// @param expiry               The expiry time associated with the AoR
+  /// @param trail                SAS trail
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* aor,
+                                     int expiry,
+                                     SAS::TrailId trail) = 0;
+};
+
+#endif

--- a/include/associated_uris.h
+++ b/include/associated_uris.h
@@ -1,0 +1,96 @@
+/**
+ * @file associated_uris.h Definitions for AssociatedURIs class.
+ *
+ * Copyright (C) Metaswitch Networks
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef ASSOCIATED_URIS_H_
+#define ASSOCIATED_URIS_H_
+
+#include <string>
+#include <vector>
+#include <map>
+#include "rapidjson/writer.h"
+#include "rapidjson/document.h"
+
+/// JSON Serialization constants
+static const char* const JSON_URI = "uri";
+static const char* const JSON_URIS = "uris";
+static const char* const JSON_BARRING = "barring";
+static const char* const JSON_WILDCARD_MAPPING ="wildcard-mapping";
+static const char* const JSON_ASSOCIATED_URIS = "associated-uris";
+static const char* const JSON_DISTINCT = "distinct";
+static const char* const JSON_WILDCARD = "wildcard";
+
+struct AssociatedURIs
+{
+public:
+  /// Gets sthe default IMPU from an implicit registration set.
+  bool get_default_impu(std::string& uri,
+                        bool emergency);
+
+  /// Checks if a URI is in the list of assiated URIs.
+  bool contains_uri(std::string uri);
+
+  /// Adds to the list of associated URIs.
+  void add_uri(std::string uri, bool barred);
+
+  /// Adds the barring status of a URI.
+  void add_barring_status(std::string uri, bool barred);
+
+  /// Clears this structure.
+  void clear_uris();
+
+  /// Returns whether a URI is barred or not.
+  bool is_impu_barred(std::string uri);
+
+  /// Returns all the unbarred URIs.
+  std::vector<std::string> get_unbarred_uris();
+
+  /// Returns all the barred URIs.
+  std::vector<std::string> get_barred_uris();
+
+  /// Returns all URIs.
+  std::vector<std::string> get_all_uris();
+
+  /// Returns the wildcard mappings.
+  std::map<std::string, std::string> get_wildcard_mapping();
+
+  /// Add a mapping between a distinct IMPU and the wildcard it belongs to
+  void add_wildcard_mapping(std::string wildcard, std::string distinct);
+
+  /// Serialize the associated URIs as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer);
+
+  // Deserialize associated URIs from a JSON object.
+  //
+  // @param s_obj - The associated URIs a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& s_obj);
+
+  // Compares the contents of this class instance to another, to see
+  // if they are the same.
+  bool operator==(AssociatedURIs associated_uris_other);
+  bool operator!=(AssociatedURIs associated_uris_other);
+
+private:
+  /// A vector of associated URIs.
+  std::vector<std::string> _associated_uris;
+
+  /// A map from the associated URIs to their barring state.
+  std::map<std::string, bool> _barred_map;
+
+  /// A map of distinct IMPUs to their wildcards
+  std::map<std::string, std::string> _distinct_to_wildcard;
+};
+
+#endif

--- a/include/astaire_aor_store.h
+++ b/include/astaire_aor_store.h
@@ -1,0 +1,118 @@
+/**
+ * @file astaire_aor_store.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef ASTAIRE_AOR_STORE_H__
+#define ASTAIRE_AOR_STORE_H__
+
+
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#include "aor_store.h"
+
+// Implementation of the AoRStore specific to our use of Memcached under Astaire
+class AstaireAoRStore: public AoRStore
+{
+public:
+  /// Constructor.
+  AstaireAoRStore(Store* store);
+
+  /// Destructor.
+  virtual ~AstaireAoRStore();
+
+  // Called through to from handlers code.
+  virtual bool has_servers() override { return _connector->underlying_store_has_servers(); }
+
+  /// Get the data for a particular address of record (registered SIP URI,
+  /// in format "sip:2125551212@example.com"), creating it if necessary.
+  /// May return NULL in case of error.  Result is owned
+  /// by caller and must be freed with delete.
+  ///
+  /// @param aor_id    The AoR to retrieve
+  /// @param trail     SAS trail
+  virtual AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail) override;
+
+  /// Update the data for a particular address of record.
+  /// if the update succeeds, this returns true.
+  ///
+  /// @param aor_id               The AoR ID to set
+  /// @param aor_pair             The AoR pair to set data from
+  /// @param expiry               The expiry time associated with the AoR
+  /// @param trail                SAS trail
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* aor,
+                                     int expiry,
+                                     SAS::TrailId trail) override;
+
+
+  /// Class used by the AstaireAoRStore to serialize AoRs from C++
+  /// objects to the JSON format used in the store, and deserialize them.
+  class JsonSerializerDeserializer
+  {
+  public:
+    /// Destructor.
+    ~JsonSerializerDeserializer() {}
+
+    /// Serialize an AoR object to the format used in the store.
+    ///
+    /// @param aor_data - The AoR object to serialize.
+    /// @return         - The serialized form.
+    std::string serialize_aor(AoR* aor_data);
+
+    /// Deserialize some data from the store into an AoR object.
+    ///
+    /// @param aor_id - The primary public ID for the AoR. This is also the key
+    ///                 used used for the record in the store.
+    /// @param s      - The data to deserialize.
+    ///
+    /// @return       - An AoR object, or NULL if the data could not be
+    ///                 deserialized (e.g. because it is corrupt).
+    AoR* deserialize_aor(const std::string& aor_id,
+                         const std::string& s);
+  };
+
+  /// Provides the interface to the data store. This is responsible for
+  /// updating and getting information from the underlying data store. The
+  /// classes that call this class are responsible for retrying the get/set
+  /// functions in case of failure.
+  class Connector
+  {
+    Connector(Store* data_store,
+              JsonSerializerDeserializer*& serializer_deserializer);
+
+    ~Connector();
+
+    AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail);
+
+    Store::Status set_aor_data(const std::string& aor_id,
+                               AoR* aor_data,
+                               int expiry,
+                               SAS::TrailId trail);
+
+    bool underlying_store_has_servers() { return (_data_store != NULL) && _data_store->has_servers(); }
+
+    Store* _data_store;
+
+    /// AstaireAoRStore is the only class that can use Connector
+    friend class AstaireAoRStore;
+
+  private:
+    JsonSerializerDeserializer* _serializer_deserializer;
+  };
+
+public:
+  Connector* _connector;
+};
+
+#endif

--- a/include/s4.h
+++ b/include/s4.h
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include "sas.h"
-#include "analyticslogger.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"
 

--- a/include/s4.h
+++ b/include/s4.h
@@ -1,0 +1,67 @@
+/**
+ * @file s4.h
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef S4_H__
+#define S4_H__
+
+#include <string>
+#include <list>
+#include <map>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sas.h"
+#include "analyticslogger.h"
+#include "astaire_aor_store.h"
+#include "httpclient.h"
+
+class S4
+{
+public:
+  /// S4 constructor.
+  ///
+  /// @param aor_store          - Pointer to the underlying data store interface
+  S4(std::string id,
+     AoRStore* aor_store,
+     std::vector<S4*> remote_s4s);
+
+  /// Destructor.
+  virtual ~S4();
+
+  HTTPCode handle_get(std::string aor_id,
+                      AoR** aor,
+                      SAS::TrailId trail);
+  HTTPCode handle_delete(std::string aor_id,
+                         SAS::TrailId trail);
+  HTTPCode handle_put(std::string aor_id,
+                      AoR* aor,
+                      SAS::TrailId id);
+  HTTPCode handle_patch(std::string aor_id,
+                        PatchObject* patch_object,
+                        SAS::TrailId trail);
+
+private:
+  void replicate_delete_cross_site(std::string aor_id,
+                                   SAS::TrailId trail);
+  void replicate_patch_cross_site(std::string aor_id,
+                                  PatchObject* po,
+                                  SAS::TrailId trail);
+  void replicate_put_cross_site(std::string aor_id,
+                                AoR* aor,
+                                SAS::TrailId trail);
+
+  std::string _id;
+  AoRStore* _aor_store;
+  std::vector<S4*> _remote_s4s;
+};
+
+#endif

--- a/include/s4sasevent.h
+++ b/include/s4sasevent.h
@@ -1,0 +1,37 @@
+/**
+ * @file s4sasevent.h S4-specific SAS event IDs
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef S4SASEVENT_H__
+#define S4SASEVENT_H__
+
+#include "sasevent.h"
+
+// @todo Define S$_BASE in cpp-common and renumber the events in the resource
+// bundle.
+const int S4_BASE = 0x810000;
+
+namespace SASEvent
+{
+  //----------------------------------------------------------------------------
+  // S4 events.
+  //----------------------------------------------------------------------------
+  const int REGSTORE_GET_FOUND = S4_BASE + 0x000070;
+  const int REGSTORE_GET_NEW = S4_BASE + 0x000071;
+  const int REGSTORE_GET_FAILURE = S4_BASE + 0x000072;
+  const int REGSTORE_SET_START = S4_BASE + 0x000073;
+  const int REGSTORE_SET_SUCCESS = S4_BASE + 0x000074;
+  const int REGSTORE_SET_FAILURE = S4_BASE + 0x000075;
+  const int REGSTORE_DESERIALIZATION_FAILED = S4_BASE + 0x000076;
+
+} //namespace SASEvent
+
+#endif
+

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -1,0 +1,546 @@
+/**
+ * @file aor.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <limits.h>
+
+#include "log.h"
+#include "aor.h"
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+/// Default constructor.
+AoR::AoR(std::string sip_uri) :
+  _notify_cseq(1),
+  _timer_id(""),
+  _scscf_uri(""),
+  _bindings(),
+  _subscriptions(),
+  _associated_uris(),
+  _cas(0),
+  _uri(sip_uri)
+{
+}
+
+
+/// Destructor.
+AoR::~AoR()
+{
+  clear(true);
+}
+
+
+/// Copy constructor.
+AoR::AoR(const AoR& other)
+{
+  common_constructor(other);
+}
+
+// Make sure assignment is deep!
+AoR& AoR::operator= (AoR const& other)
+{
+  if (this != &other)
+  {
+    clear(true);
+    common_constructor(other);
+  }
+
+  return *this;
+}
+
+void AoR::common_constructor(const AoR& other)
+{
+  for (Bindings::const_iterator i = other._bindings.begin();
+       i != other._bindings.end();
+       ++i)
+  {
+    Binding* bb = new Binding(*i->second);
+    _bindings.insert(std::make_pair(i->first, bb));
+  }
+
+  for (Subscriptions::const_iterator i = other._subscriptions.begin();
+       i != other._subscriptions.end();
+       ++i)
+  {
+    Subscription* ss = new Subscription(*i->second);
+    _subscriptions.insert(std::make_pair(i->first, ss));
+  }
+
+  _associated_uris = AssociatedURIs(other._associated_uris);
+  _notify_cseq = other._notify_cseq;
+  _timer_id = other._timer_id;
+  _cas = other._cas;
+  _uri = other._uri;
+  _scscf_uri = other._scscf_uri;
+}
+
+/// Clear all the bindings and subscriptions from this object.
+void AoR::clear(bool clear_emergency_bindings)
+{
+  for (Bindings::iterator i = _bindings.begin();
+       i != _bindings.end();
+       )
+  {
+    if ((clear_emergency_bindings) || (!i->second->_emergency_registration))
+    {
+      delete i->second;
+      _bindings.erase(i++);
+    }
+    else
+    {
+      ++i;
+    }
+  }
+
+  if (clear_emergency_bindings)
+  {
+    _bindings.clear();
+  }
+
+  for (Subscriptions::iterator i = _subscriptions.begin();
+       i != _subscriptions.end();
+       ++i)
+  {
+    delete i->second;
+  }
+
+  _subscriptions.clear();
+  _associated_uris.clear_uris();
+}
+
+
+/// Retrieve a binding by binding identifier, creating an empty one if
+/// necessary.  The created binding is completely empty, even the Contact URI
+/// field.
+Binding* AoR::get_binding(const std::string& binding_id)
+{
+  Binding* b;
+  AoR::Bindings::const_iterator i = _bindings.find(binding_id);
+  if (i != _bindings.end())
+  {
+    b = i->second;
+  }
+  else
+  {
+    // No existing binding with this id, so create a new one.
+    b = new Binding(_uri);
+    b->_expires = 0;
+    _bindings.insert(std::make_pair(binding_id, b));
+  }
+  return b;
+}
+
+
+/// Removes any binding that had the given ID.  If there is no such binding,
+/// does nothing.
+void AoR::remove_binding(const std::string& binding_id)
+{
+  AoR::Bindings::iterator i = _bindings.find(binding_id);
+  if (i != _bindings.end())
+  {
+    delete i->second;
+    _bindings.erase(i);
+  }
+}
+
+/// Retrieve a subscription by To tag, creating an empty subscription if
+/// necessary.
+Subscription* AoR::get_subscription(const std::string& to_tag)
+{
+  Subscription* s;
+  AoR::Subscriptions::const_iterator i = _subscriptions.find(to_tag);
+  if (i != _subscriptions.end())
+  {
+    s = i->second;
+  }
+  else
+  {
+    // No existing subscription with this tag, so create a new one.
+    s = new Subscription;
+    _subscriptions.insert(std::make_pair(to_tag, s));
+  }
+  return s;
+}
+
+
+/// Removes the subscription with the specified tag.  If there is no such
+/// subscription, does nothing.
+void AoR::remove_subscription(const std::string& to_tag)
+{
+  AoR::Subscriptions::iterator i = _subscriptions.find(to_tag);
+  if (i != _subscriptions.end())
+  {
+    delete i->second;
+    _subscriptions.erase(i);
+  }
+}
+
+/// Remove all the bindings from an AOR object
+void AoR::clear_bindings()
+{
+  for (Bindings::const_iterator i = _bindings.begin();
+       i != _bindings.end();
+       ++i)
+  {
+    delete i->second;
+  }
+
+  // Clear the bindings map.
+  _bindings.clear();
+}
+
+
+void Binding::
+  to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_URI); writer.String(_uri.c_str());
+    writer.String(JSON_CID); writer.String(_cid.c_str());
+    writer.String(JSON_CSEQ); writer.Int(_cseq);
+    writer.String(JSON_EXPIRES); writer.Int(_expires);
+    writer.String(JSON_PRIORITY); writer.Int(_priority);
+
+    writer.String(JSON_PARAMS);
+    writer.StartObject();
+    {
+      for (std::map<std::string, std::string>::const_iterator p = _params.begin();
+           p != _params.end();
+           ++p)
+      {
+        writer.String(p->first.c_str()); writer.String(p->second.c_str());
+      }
+    }
+    writer.EndObject();
+
+    writer.String(JSON_PATH_HEADERS);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator p = _path_headers.begin();
+           p != _path_headers.end();
+           ++p)
+      {
+        writer.String(p->c_str());
+      }
+    }
+    writer.EndArray();
+
+    // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
+    writer.String(JSON_PATHS);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator p = _path_uris.begin();
+           p != _path_uris.end();
+           ++p)
+      {
+        writer.String(p->c_str());
+      }
+    }
+    writer.EndArray();
+
+    writer.String(JSON_PRIVATE_ID); writer.String(_private_id.c_str());
+    writer.String(JSON_EMERGENCY_REG); writer.Bool(_emergency_registration);
+  }
+  writer.EndObject();
+}
+
+void Binding::from_json(const rapidjson::Value& b_obj)
+{
+
+  JSON_GET_STRING_MEMBER(b_obj, JSON_URI, _uri);
+  JSON_GET_STRING_MEMBER(b_obj, JSON_CID, _cid);
+  JSON_GET_INT_MEMBER(b_obj, JSON_CSEQ, _cseq);
+  JSON_GET_INT_MEMBER(b_obj, JSON_EXPIRES, _expires);
+  JSON_GET_INT_MEMBER(b_obj, JSON_PRIORITY, _priority);
+
+  JSON_ASSERT_CONTAINS(b_obj, JSON_PARAMS);
+  JSON_ASSERT_OBJECT(b_obj[JSON_PARAMS]);
+  const rapidjson::Value& params_obj = b_obj[JSON_PARAMS];
+
+  for (rapidjson::Value::ConstMemberIterator params_it = params_obj.MemberBegin();
+       params_it != params_obj.MemberEnd();
+       ++params_it)
+  {
+    JSON_ASSERT_STRING(params_it->value);
+    _params[params_it->name.GetString()] = params_it->value.GetString();
+  }
+
+  if (b_obj.HasMember(JSON_PATH_HEADERS))
+  {
+    JSON_ASSERT_ARRAY(b_obj[JSON_PATH_HEADERS]);
+    const rapidjson::Value& path_headers_arr = b_obj[JSON_PATH_HEADERS];
+
+    for (rapidjson::Value::ConstValueIterator path_headers_it = path_headers_arr.Begin();
+         path_headers_it != path_headers_arr.End();
+         ++path_headers_it)
+    {
+      JSON_ASSERT_STRING(*path_headers_it);
+      _path_headers.push_back(path_headers_it->GetString());
+    }
+  }
+
+  // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
+  if (b_obj.HasMember(JSON_PATHS))
+  {
+    JSON_ASSERT_ARRAY(b_obj[JSON_PATHS]);
+    const rapidjson::Value& path_uris_arr = b_obj[JSON_PATHS];
+
+    for (rapidjson::Value::ConstValueIterator path_uris_it = path_uris_arr.Begin();
+         path_uris_it != path_uris_arr.End();
+         ++path_uris_it)
+    {
+      JSON_ASSERT_STRING(*path_uris_it);
+      _path_uris.push_back(path_uris_it->GetString());
+    }
+  }
+
+  JSON_GET_STRING_MEMBER(b_obj, JSON_PRIVATE_ID, _private_id);
+  JSON_GET_BOOL_MEMBER(b_obj, JSON_EMERGENCY_REG, _emergency_registration);
+}
+
+void Subscription::
+  to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_REQ_URI); writer.String(_req_uri.c_str());
+    writer.String(JSON_FROM_URI); writer.String(_from_uri.c_str());
+    writer.String(JSON_FROM_TAG); writer.String(_from_tag.c_str());
+    writer.String(JSON_TO_URI); writer.String(_to_uri.c_str());
+    writer.String(JSON_TO_TAG); writer.String(_to_tag.c_str());
+    writer.String(JSON_CID); writer.String(_cid.c_str());
+
+    writer.String(JSON_ROUTES);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator r = _route_uris.begin();
+           r != _route_uris.end();
+           ++r)
+      {
+        writer.String(r->c_str());
+      }
+    }
+    writer.EndArray();
+
+    writer.String(JSON_EXPIRES); writer.Int(_expires);
+  }
+  writer.EndObject();
+}
+
+void Subscription::from_json(const rapidjson::Value& s_obj)
+{
+  JSON_GET_STRING_MEMBER(s_obj, JSON_REQ_URI, _req_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_FROM_URI, _from_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_FROM_TAG, _from_tag);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_TO_URI, _to_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_TO_TAG, _to_tag);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_CID, _cid);
+
+  JSON_ASSERT_CONTAINS(s_obj, JSON_ROUTES);
+  JSON_ASSERT_ARRAY(s_obj[JSON_ROUTES]);
+  const rapidjson::Value& routes_arr = s_obj[JSON_ROUTES];
+
+  for (rapidjson::Value::ConstValueIterator routes_it = routes_arr.Begin();
+       routes_it != routes_arr.End();
+       ++routes_it)
+  {
+    JSON_ASSERT_STRING(*routes_it);
+    _route_uris.push_back(routes_it->GetString());
+  }
+
+  JSON_GET_INT_MEMBER(s_obj, JSON_EXPIRES, _expires);
+}
+
+// Utility function to return the expiry time of the binding or subscription due
+// to expire next. If the function finds no expiry times in the bindings or
+// subscriptions it returns 0. This function should never be called on an empty AoR,
+// so a 0 is indicative of something wrong with the _expires values of AoR members.
+int AoR::get_next_expires()
+{
+  // Set a temp int to INT_MAX to compare expiry times to.
+  int _next_expires = INT_MAX;
+
+  for (AoR::Bindings::const_iterator b = _bindings.begin();
+       b != _bindings.end();
+       ++b)
+  {
+    if (b->second->_expires < _next_expires)
+    {
+      _next_expires = b->second->_expires;
+    }
+  }
+  for (AoR::Subscriptions::const_iterator s = _subscriptions.begin();
+       s != _subscriptions.end();
+       ++s)
+  {
+    if (s->second->_expires < _next_expires)
+    {
+      _next_expires = s->second->_expires;
+    }
+  }
+
+  // If nothing has altered the _next_expires, the AoR is empty and invalid.
+  // Return 0 to indicate there is nothing to expire.
+  if (_next_expires == INT_MAX)
+  {
+    return 0;
+  }
+  // Otherwise we return the value found.
+  return _next_expires;
+}
+
+void AoR::copy_aor(AoR* source_aor)
+{
+  for (Bindings::const_iterator i = source_aor->bindings().begin();
+       i != source_aor->bindings().end();
+       ++i)
+  {
+    Binding* src = i->second;
+    Binding* dst = get_binding(i->first);
+    *dst = *src;
+  }
+
+  for (Subscriptions::const_iterator i = source_aor->subscriptions().begin();
+       i != source_aor->subscriptions().end();
+       ++i)
+  {
+    Subscription* src = i->second;
+    Subscription* dst = get_subscription(i->first);
+    *dst = *src;
+  }
+
+  _associated_uris = AssociatedURIs(source_aor->_associated_uris);
+  _notify_cseq = source_aor->_notify_cseq;
+  _timer_id = source_aor->_timer_id;
+  _uri = source_aor->_uri;
+  _scscf_uri = source_aor->_scscf_uri;
+}
+
+AoR::Bindings AoRPair::get_updated_bindings()
+{
+  AoR::Bindings updated_bindings;
+
+  // Iterate over the bindings in the current AoR. Figure out if the bindings
+  // have been created or updated.
+  for (std::pair<std::string, Binding*> current_aor_binding :
+         _current_aor->bindings())
+  {
+    std::string b_id = current_aor_binding.first;
+    Binding* binding = current_aor_binding.second;
+
+    // Find any binding match in the original AoR
+    AoR::Bindings::const_iterator orig_aor_binding_match =
+      _orig_aor->bindings().find(b_id);
+
+    // If the binding is only in the current AoR, it has been created
+    if (orig_aor_binding_match == _orig_aor->bindings().end())
+    {
+      TRC_DEBUG("Binding %s has been created", current_aor_binding.first.c_str());
+      updated_bindings.insert(std::make_pair(b_id, binding));
+    }
+    else
+    {
+      // The binding is in both AoRs. Check if the expiry time has changed at all
+      if (orig_aor_binding_match->second->_expires != binding->_expires)
+      {
+        TRC_DEBUG("Binding %s expiry has been changed", b_id.c_str());
+        updated_bindings.insert(std::make_pair(b_id, binding));
+      }
+      else
+      {
+        TRC_DEBUG("Binding %s is unchanged", b_id.c_str());
+      }
+    }
+  }
+  return updated_bindings;
+}
+
+AoR::Subscriptions AoRPair::get_updated_subscriptions()
+{
+  AoR::Subscriptions updated_subscriptions;
+
+  // Iterate over the subscriptions in the current AoR. Figure out if the
+  // subscriptions have been created or updated.
+  for (std::pair<std::string, Subscription*> current_aor_subscription :
+         _current_aor->subscriptions())
+  {
+    std::string s_id = current_aor_subscription.first;
+    Subscription* subscription = current_aor_subscription.second;
+
+    // Find any subscriptions match in the original AoR
+    AoR::Subscriptions::const_iterator orig_aor_subscription_match =
+      _orig_aor->subscriptions().find(s_id);
+
+    // If the subscription is only in the current AoR, it has been created
+    if (orig_aor_subscription_match == _orig_aor->subscriptions().end())
+    {
+      TRC_DEBUG("Subscription %s has been created", current_aor_subscription.first.c_str());
+      updated_subscriptions.insert(std::make_pair(s_id, subscription));
+    }
+    else
+    {
+      // The subscription is in both AoRs. Check if the expiry time has changed at all
+      if (orig_aor_subscription_match->second->_expires != subscription->_expires)
+      {
+        TRC_DEBUG("Subscription %s expiry has been changed", s_id.c_str());
+        updated_subscriptions.insert(std::make_pair(s_id, subscription));
+      }
+      else
+      {
+        TRC_DEBUG("Subscription %s is unchanged", s_id.c_str());
+      }
+    }
+  }
+
+  return updated_subscriptions;
+}
+
+AoR::Bindings AoRPair::get_removed_bindings()
+{
+  AoR::Bindings removed_bindings;
+
+  // Iterate over original bindings and record those not in current AoR
+  for (std::pair<std::string, Binding*> orig_aor_binding :
+         _orig_aor->bindings())
+  {
+    if (_current_aor->bindings().find(orig_aor_binding.first) ==
+        _current_aor->bindings().end())
+    {
+      // Binding is gone (which may mean deregistration or expiry)
+      TRC_DEBUG("Binding %s has been removed", orig_aor_binding.first.c_str());
+      removed_bindings.insert(std::make_pair(orig_aor_binding.first,
+                                             orig_aor_binding.second));
+    }
+  }
+
+  return removed_bindings;
+}
+
+AoR::Subscriptions AoRPair::get_removed_subscriptions()
+{
+  AoR::Subscriptions removed_subscriptions;
+
+  // Iterate over original subscriptions and record those not in current AoR
+  for (std::pair<std::string, Subscription*> orig_aor_subscription :
+         _orig_aor->subscriptions())
+  {
+    // Is this subscription present in the new AoR?
+    if (_current_aor->subscriptions().find(orig_aor_subscription.first) ==
+        _current_aor->subscriptions().end())
+    {
+      // Subscription is gone
+      TRC_DEBUG("Subscription %s is no longer present",
+                    orig_aor_subscription.first.c_str());
+      removed_subscriptions.insert(std::make_pair(orig_aor_subscription.first,
+                                                  orig_aor_subscription.second));
+    }
+  }
+  return removed_subscriptions;
+}

--- a/src/associated_uris.cpp
+++ b/src/associated_uris.cpp
@@ -1,0 +1,240 @@
+/**
+ * @file associated_uris.cpp Implementation of the AssociatedURIs class.
+ *
+ * Copyright (C) Metaswitch Networks
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "associated_uris.h"
+#include "log.h"
+
+#include <algorithm>
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+// Gets the default URI. We return the first unbarred URI. If there is no
+// unbarred URI, we don't return anything unless it is an emergency in which
+// case we return the first URI.
+bool AssociatedURIs::get_default_impu(std::string& uri,
+                                      bool emergency)
+{
+  std::vector<std::string> unbarred_uris = this->get_unbarred_uris();
+  if (!unbarred_uris.empty())
+  {
+    uri = unbarred_uris.front();
+    return true;
+  }
+
+  if ((emergency) &&
+      (!_associated_uris.empty()))
+  {
+    uri = _associated_uris.front();
+    return true;
+  }
+
+  return false;
+}
+
+// Checks if the URI is in the list of associated URIs.
+bool AssociatedURIs::contains_uri(std::string uri)
+{
+  return (std::find(_associated_uris.begin(), _associated_uris.end(), uri) !=
+          _associated_uris.end());
+}
+
+// Adds a URI and its barring state to the list of associated URIs.
+void AssociatedURIs::add_uri(std::string uri,
+                             bool barred)
+{
+  _associated_uris.push_back(uri);
+  add_barring_status(uri, barred);
+}
+
+// Adds the barring state of a URI. This map includes URIs that aren't in the
+// associated URI list (e.g. it includes non-distinct IMPUs)
+void AssociatedURIs::add_barring_status(std::string uri,
+                                        bool barred)
+{
+  _barred_map[uri] = barred;
+}
+
+// Removes all URIs.
+void AssociatedURIs::clear_uris()
+{
+  _associated_uris.clear();
+  _barred_map.clear();
+  _distinct_to_wildcard.clear();
+}
+
+// Returns if the specified URI is barred.
+bool AssociatedURIs::is_impu_barred(std::string uri)
+{
+  // Sometimes we don't have the barring status of the specific URI as it's
+  // actually an URI that matches a wildcard - get the wildcard URI before
+  // we check the barring status. In the case where a non-distinct IMPU
+  // has had its barring indication set specifically in the IMS subscription
+  // we got from the HSS then it was directly added to the _barred_map (and
+  // not added to the _distinct_to_wildcard map).
+  std::string uri_to_check = uri;
+  if (_distinct_to_wildcard.find(uri) != _distinct_to_wildcard.end())
+  {
+    uri_to_check = _distinct_to_wildcard[uri];
+  }
+
+  if (_barred_map.find(uri_to_check) != _barred_map.end())
+  {
+    return _barred_map[uri_to_check];
+  }
+  else
+  {
+    // We shouldn't ever end up here - return false (we do hit this in UTs
+    // though as we don't always use valid data).
+    TRC_DEBUG("No barring information available for %s", uri.c_str());
+    return false;
+  }
+}
+
+// Returns all unbarred associated URIs.
+std::vector<std::string> AssociatedURIs::get_unbarred_uris()
+{
+  std::vector<std::string> unbarred_uris;
+
+  for (std::string uri : _associated_uris)
+  {
+    if (!_barred_map[uri])
+    {
+      unbarred_uris.push_back(uri);
+    }
+  }
+
+  return unbarred_uris;
+}
+
+// Returns all barred associated URIs.
+std::vector<std::string> AssociatedURIs::get_barred_uris()
+{
+  std::vector<std::string> barred_uris;
+
+  for (std::string uri : _associated_uris)
+  {
+    if (_barred_map[uri])
+    {
+      barred_uris.push_back(uri);
+    }
+  }
+
+  return barred_uris;
+}
+
+// Returns all associated URIs.
+std::vector<std::string> AssociatedURIs::get_all_uris()
+{
+  return _associated_uris;
+}
+
+// Returns the wildcard mapping
+std::map<std::string, std::string> AssociatedURIs::get_wildcard_mapping()
+{
+  return _distinct_to_wildcard;
+}
+
+// Sets up the link between a distinct IMPU and its wildcard.
+void AssociatedURIs::add_wildcard_mapping(std::string wildcard,
+                                          std::string distinct)
+{
+  _distinct_to_wildcard.insert(std::make_pair(distinct, wildcard));
+}
+
+// Expected format of json:
+// {"uris": [{"uri": "sip:uri", "barring": false},.......],
+//  "wildcard-mapping": {"distinct": ".....", "wildcard": "......"}}
+void AssociatedURIs::to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer)
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_URIS);
+    writer.StartArray();
+    for (std::vector<std::string>::iterator uris_it = _associated_uris.begin();
+         uris_it != _associated_uris.end();
+         uris_it++)
+    {
+      bool uri_barred = is_impu_barred(*uris_it);
+      writer.StartObject();
+      {
+        writer.String(JSON_URI); writer.String((*uris_it).c_str());
+        writer.String(JSON_BARRING); writer.Bool(uri_barred);
+      }
+      writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.String(JSON_WILDCARD_MAPPING);
+    writer.StartObject();
+    {
+      if (get_wildcard_mapping().size() != 0)
+      {
+        writer.String(JSON_DISTINCT);
+        writer.String(get_wildcard_mapping().begin()->first.c_str());
+        writer.String(JSON_WILDCARD);
+        writer.String(get_wildcard_mapping().begin()->second.c_str());
+      }
+    }
+    writer.EndObject();
+  }
+  writer.EndObject();
+}
+
+void AssociatedURIs::from_json(const rapidjson::Value& au_obj)
+{
+  JSON_ASSERT_CONTAINS(au_obj, JSON_URIS);
+  JSON_ASSERT_ARRAY(au_obj[JSON_URIS]);
+  const rapidjson::Value& associated_uris_arr = au_obj[JSON_URIS];
+
+  clear_uris();
+
+  for (rapidjson::Value::ConstValueIterator associated_uris_it = associated_uris_arr.Begin();
+       associated_uris_it != associated_uris_arr.End();
+       ++associated_uris_it)
+  {
+    std::string uri;
+    bool barring;
+    JSON_GET_STRING_MEMBER(*associated_uris_it, JSON_URI, uri);
+    JSON_GET_BOOL_MEMBER(*associated_uris_it, JSON_BARRING, barring);
+    TRC_DEBUG("From JSON - Adding URI: %s, barring: %d", uri.c_str(), barring);
+    add_uri(uri, barring);
+  }
+
+  JSON_ASSERT_CONTAINS(au_obj, JSON_WILDCARD_MAPPING);
+  JSON_ASSERT_OBJECT(au_obj[JSON_WILDCARD_MAPPING]);
+  const rapidjson::Value& wildcard_obj = au_obj[JSON_WILDCARD_MAPPING];
+
+  if (wildcard_obj.HasMember(JSON_DISTINCT))
+  {
+    std::string distinct;
+    std::string wildcard;
+    JSON_GET_STRING_MEMBER(wildcard_obj, JSON_DISTINCT, distinct)
+    JSON_GET_STRING_MEMBER(wildcard_obj, JSON_WILDCARD, wildcard)
+
+    add_wildcard_mapping(distinct, wildcard);
+  }
+}
+
+bool AssociatedURIs::operator==(AssociatedURIs associated_uris_other)
+{
+  // Only comparing associated URIs and barring, not wildcard mappings
+  if (_associated_uris != associated_uris_other.get_all_uris() ||
+      get_barred_uris() != associated_uris_other.get_barred_uris())
+  {
+    return false;
+  }
+  return true;
+}
+
+bool AssociatedURIs::operator!=(AssociatedURIs associated_uris_other)
+{
+  return !(operator==(associated_uris_other));
+}

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -1,0 +1,301 @@
+/**
+ * @file astaire_aor_store.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#include "log.h"
+#include "s4sasevent.h"
+#include "astaire_aor_store.h"
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+
+AstaireAoRStore::AstaireAoRStore(Store* store) : AoRStore()
+{
+  JsonSerializerDeserializer* serializer_deserializer = new JsonSerializerDeserializer();
+  _connector = new Connector(store, serializer_deserializer); // Takes ownership of serializer_deserializer
+}
+
+AstaireAoRStore::~AstaireAoRStore()
+{
+  // Ownership of serializer_deserializer passed to _connector
+  delete _connector; _connector = NULL;
+}
+
+/// AstaireAoRStore methods
+
+/// Calls through into the connector get and set commands
+AoR* AstaireAoRStore::get_aor_data(const std::string& aor_id,
+                                   SAS::TrailId trail)
+{
+  return _connector->get_aor_data(aor_id, trail);
+}
+
+
+Store::Status AstaireAoRStore::set_aor_data(const std::string& aor_id,
+                                            AoR* aor,
+                                            int expiry,
+                                            SAS::TrailId trail)
+{
+  return _connector->set_aor_data(aor_id,
+                                  aor,
+                                  expiry,
+                                  trail);
+}
+
+/// AstaireAoRStore::Connector Methods
+
+AstaireAoRStore::Connector::Connector(Store* data_store,
+                            JsonSerializerDeserializer*& serializer_deserializer) :
+  _data_store(data_store),
+  _serializer_deserializer(serializer_deserializer)
+{
+  // We have taken ownership of the serializer_deserializer.
+  serializer_deserializer = NULL;
+}
+
+AstaireAoRStore::Connector::~Connector()
+{
+  delete _serializer_deserializer; _serializer_deserializer = NULL;
+}
+
+/// Retrieve the registration data for a given SIP Address of Record, creating
+/// an empty record if no data exists for the AoR.
+///
+/// @param aor_id       The SIP Address of Record for the registration
+AoR* AstaireAoRStore::Connector::get_aor_data(
+                                             const std::string& aor_id,
+                                             SAS::TrailId trail)
+{
+  TRC_DEBUG("Get AoR data for %s", aor_id.c_str());
+  AoR* aor_data = NULL;
+
+  std::string data;
+  uint64_t cas;
+  Store::Status status = _data_store->get_data("reg", aor_id, data, cas, trail);
+
+  if (status == Store::Status::OK)
+  {
+    // Retrieved the data, so deserialize it.
+    TRC_DEBUG("Data store returned a record, CAS = %ld", cas);
+    aor_data = _serializer_deserializer->deserialize_aor(aor_id, data);
+
+    if (aor_data != NULL)
+    {
+      aor_data->_cas = cas;
+
+      SAS::Event event(trail, SASEvent::REGSTORE_GET_FOUND, 0);
+      event.add_var_param(aor_id);
+      SAS::report_event(event);
+    }
+    else
+    {
+      // Could not deserialize the record. Treat it as not found.
+      TRC_INFO("Failed to deserialize record");
+      SAS::Event event(trail, SASEvent::REGSTORE_DESERIALIZATION_FAILED, 0);
+      event.add_var_param(aor_id);
+      event.add_var_param(data);
+      SAS::report_event(event);
+    }
+  }
+  else if (status == Store::Status::NOT_FOUND)
+  {
+    // Data store didn't find the record, so create a new blank record.
+    aor_data = new AoR(aor_id);
+
+    SAS::Event event(trail, SASEvent::REGSTORE_GET_NEW, 0);
+    event.add_var_param(aor_id);
+    SAS::report_event(event);
+
+    TRC_DEBUG("Data store returned not found, so create new record, CAS = %ld",
+              aor_data->_cas);
+  }
+  else
+  {
+    SAS::Event event(trail, SASEvent::REGSTORE_GET_FAILURE, 0);
+    event.add_var_param(aor_id);
+    SAS::report_event(event);
+  }
+
+  return aor_data;
+}
+
+Store::Status AstaireAoRStore::Connector::set_aor_data(
+                                            const std::string& aor_id,
+                                            AoR* aor_data,
+                                            int expiry,
+                                            SAS::TrailId trail)
+{
+  std::string data = _serializer_deserializer->serialize_aor(aor_data);
+
+  SAS::Event event(trail, SASEvent::REGSTORE_SET_START, 0);
+  event.add_var_param(aor_id);
+  SAS::report_event(event);
+
+  Store::Status status = _data_store->set_data("reg",
+                                               aor_id,
+                                               data,
+                                               aor_data->_cas,
+                                               expiry,
+                                               trail);
+
+  TRC_DEBUG("Data store set_data returned %d", status);
+
+  if (status == Store::Status::OK)
+  {
+    SAS::Event event2(trail, SASEvent::REGSTORE_SET_SUCCESS, 0);
+    event2.add_var_param(aor_id);
+    SAS::report_event(event2);
+  }
+  else
+  {
+    SAS::Event event2(trail, SASEvent::REGSTORE_SET_FAILURE, 0);
+    event2.add_var_param(aor_id);
+    SAS::report_event(event2);
+  }
+
+  return status;
+}
+
+
+//
+// (De)serializer for the JSON SubscriberDataManager format.
+//
+
+AoR* AstaireAoRStore::JsonSerializerDeserializer::
+  deserialize_aor(const std::string& aor_id, const std::string& s)
+{
+  TRC_DEBUG("Deserialize JSON document: %s", s.c_str());
+
+  rapidjson::Document doc;
+  doc.Parse<0>(s.c_str());
+
+  if (doc.HasParseError())
+  {
+    TRC_DEBUG("Failed to parse document: %s\nError: %s",
+              s.c_str(),
+              rapidjson::GetParseError_En(doc.GetParseError()));
+    return NULL;
+  }
+
+  AoR* aor = new AoR(aor_id);
+
+  try
+  {
+    JSON_ASSERT_OBJECT(doc);
+    JSON_ASSERT_CONTAINS(doc, JSON_BINDINGS);
+    JSON_ASSERT_OBJECT(doc[JSON_BINDINGS]);
+    const rapidjson::Value& bindings_obj = doc[JSON_BINDINGS];
+
+    for (rapidjson::Value::ConstMemberIterator bindings_it = bindings_obj.MemberBegin();
+         bindings_it != bindings_obj.MemberEnd();
+         ++bindings_it)
+    {
+      TRC_DEBUG("  Binding: %s", bindings_it->name.GetString());
+      Binding* b = aor->get_binding(bindings_it->name.GetString());
+
+      JSON_ASSERT_OBJECT(bindings_it->value);
+      const rapidjson::Value& b_obj = bindings_it->value;
+
+      b->from_json(b_obj);
+    }
+
+    JSON_ASSERT_CONTAINS(doc, JSON_SUBSCRIPTIONS);
+    JSON_ASSERT_OBJECT(doc[JSON_SUBSCRIPTIONS]);
+    const rapidjson::Value& subscriptions_obj = doc[JSON_SUBSCRIPTIONS];
+
+    for (rapidjson::Value::ConstMemberIterator subscriptions_it = subscriptions_obj.MemberBegin();
+         subscriptions_it != subscriptions_obj.MemberEnd();
+         ++subscriptions_it)
+    {
+      TRC_DEBUG("  Subscription: %s", subscriptions_it->name.GetString());
+      Subscription* s = aor->get_subscription(subscriptions_it->name.GetString());
+
+      JSON_ASSERT_OBJECT(subscriptions_it->value);
+      const rapidjson::Value& s_obj = subscriptions_it->value;
+
+      s->from_json(s_obj);
+    }
+
+    if (doc.HasMember(JSON_ASSOCIATED_URIS))
+    {
+      JSON_ASSERT_OBJECT(doc[JSON_ASSOCIATED_URIS]);
+      const rapidjson::Value& au_obj = doc[JSON_ASSOCIATED_URIS];
+      aor->_associated_uris.from_json(au_obj);
+    }
+
+    JSON_GET_INT_MEMBER(doc, JSON_NOTIFY_CSEQ, aor->_notify_cseq);
+
+    JSON_SAFE_GET_STRING_MEMBER(doc, JSON_TIMER_ID, aor->_timer_id);
+    JSON_SAFE_GET_STRING_MEMBER(doc, JSON_SCSCF_URI, aor->_scscf_uri);
+  }
+  catch(JsonFormatError err)
+  {
+    TRC_INFO("Failed to deserialize JSON document (hit error at %s:%d)",
+             err._file, err._line);
+    delete aor; aor = NULL;
+  }
+
+  return aor;
+}
+
+
+std::string AstaireAoRStore::JsonSerializerDeserializer::serialize_aor(AoR* aor_data)
+{
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+
+  writer.StartObject();
+  {
+    //
+    // Bindings
+    //
+    writer.String(JSON_BINDINGS);
+    writer.StartObject();
+    {
+      for (AoR::Bindings::const_iterator it = aor_data->bindings().begin();
+           it != aor_data->bindings().end();
+           ++it)
+      {
+        writer.String(it->first.c_str());
+        it->second->to_json(writer);
+      }
+    }
+    writer.EndObject();
+
+    //
+    // Subscriptions.
+    //
+    writer.String(JSON_SUBSCRIPTIONS);
+    writer.StartObject();
+    {
+      for (AoR::Subscriptions::const_iterator it = aor_data->subscriptions().begin();
+           it != aor_data->subscriptions().end();
+           ++it)
+      {
+        writer.String(it->first.c_str());
+        it->second->to_json(writer);
+      }
+    }
+    writer.EndObject();
+
+    // Associated URIs
+    writer.String(JSON_ASSOCIATED_URIS);
+    aor_data->_associated_uris.to_json(writer);
+
+    // Notify Cseq flag
+    writer.String(JSON_NOTIFY_CSEQ); writer.Int(aor_data->_notify_cseq);
+    writer.String(JSON_TIMER_ID); writer.String(aor_data->_timer_id.c_str());
+    writer.String(JSON_SCSCF_URI); writer.String(aor_data->_scscf_uri.c_str());
+  }
+  writer.EndObject();
+
+  return sb.GetString();
+}

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -1,0 +1,336 @@
+/**
+ * @file s4.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+// Common STL includes.
+#include <cassert>
+#include <vector>
+#include <map>
+#include <set>
+#include <list>
+#include <queue>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <iomanip>
+#include <algorithm>
+#include <time.h>
+
+#include "log.h"
+#include "utils.h"
+#include "s4.h"
+#include "astaire_aor_store.h"
+
+// SDM-REFACTOR-TODO:
+// Commonise logic in the handles? Or at least make more similar.
+// TRC statements
+// SAS logging (poss already covered by memcached logs)
+// Lifetimes of AoRs?
+// Implement PATCH
+// Implement PATCH/PUT conversion, and protect against loops
+// Implement max_expiry
+// Full UT
+
+S4::S4(std::string id,
+       AoRStore* aor_store,
+       std::vector<S4*> remote_s4s) :
+  _id(id),
+  _aor_store(aor_store),
+  _remote_s4s(remote_s4s)
+{
+}
+
+S4::~S4()
+{
+}
+
+HTTPCode S4::handle_get(std::string aor_id,
+                        AoR** aor,
+                        SAS::TrailId trail)
+{
+  HTTPCode rc;
+  bool retry_get = true;
+
+  while (retry_get)
+  {
+    *aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL || *aor == NULL)
+    {
+      // Failed to get data for the AoR because there is no connection
+      // to the store. This will already have been SAS logged by the AoR store.
+      TRC_DEBUG("Store error for %s. Failed to get AoR for %s from store",
+                _id.c_str(),
+                aor_id.c_str());
+      rc = HTTP_SERVER_ERROR;
+      retry_get = false;
+    }
+    else if ((*aor)->bindings().empty())
+    {
+      // If we don't have any bindings, try the remote stores.
+      TRC_DEBUG("AoR is empty for %s in %s",
+                aor_id.c_str(),
+                _id.c_str());
+      rc = HTTP_NOT_FOUND;
+      retry_get = false;
+
+      for (S4* remote_s4 : _remote_s4s)
+      {
+        AoR* remote_aor = NULL;
+        HTTPCode remote_rc = remote_s4->handle_get(aor_id, &remote_aor, trail);
+
+        if (remote_rc == HTTP_OK)
+        {
+          // The remote store has an entry for this AoR and it has bindings -
+          // copy the information across.
+          (*aor)->copy_aor(remote_aor);
+          Store::Status store_rc = _aor_store->set_aor_data(aor_id, *aor, (*aor)->get_expiry(), trail);
+
+          if (store_rc == Store::Status::ERROR)
+          {
+            // We haven't been able to write the data back to memcached.
+            rc = HTTP_SERVER_ERROR;
+          }
+          else if (store_rc == Store::Status::OK)
+          {
+            rc = HTTP_OK;
+          }
+          else if (store_rc == Store::Status::DATA_CONTENTION)
+          {
+            retry_get = true;
+          }
+
+          break;
+        }
+        else if (remote_rc == HTTP_NOT_FOUND)
+        {
+          // We created an AoR but it's empty. Free it off.
+          delete remote_aor; remote_aor = NULL;
+        }
+      }
+    }
+    else
+    {
+      retry_get = false;
+      rc = HTTP_OK;
+    }
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_delete(std::string aor_id, SAS::TrailId trail)
+{
+  Store::Status store_rc = Store::Status::DATA_CONTENTION;
+
+  while (store_rc == Store::Status::DATA_CONTENTION)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL)
+    {
+      store_rc = Store::Status::ERROR;
+    }
+    else if (aor->bindings().empty())
+    {
+      store_rc = Store::Status::OK;
+    }
+    else
+    {
+      // Clear the AoR.
+      aor->clear(true);
+
+      // Write the empty AoR back to the store.
+      store_rc = _aor_store->set_aor_data(aor_id, aor, aor->get_expiry(), trail);
+    }
+  }
+
+  HTTPCode rc;
+
+  if (store_rc == Store::Status::OK)
+  {
+    // Subscriber has been deleted from the local site, so send the DELETE
+    // out to the remote sites. The response to the SM is always going to be
+    // OK independently of whether any remote DELETEs are successful.
+    replicate_delete_cross_site(aor_id, trail);
+    rc = HTTP_OK;
+  }
+  else
+  {
+    // Failed to delete data - we don't try and delete the subscriber from
+    // any remote sites.
+    TRC_DEBUG("Failed to delete subscriber %s from %s",
+              aor_id.c_str(),
+              _id.c_str());
+    rc = HTTP_SERVER_ERROR;
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_put(std::string aor_id,
+                        AoR* new_aor,
+                        SAS::TrailId trail)
+{
+  HTTPCode rc = HTTP_OK;
+
+  while (true)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* current_aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (current_aor == NULL)
+    {
+      rc = HTTP_SERVER_ERROR;
+      break;
+    }
+    else if (!current_aor->bindings().empty())
+    {
+      // We already have data for this AoR, so we shouldn't have had a PUT for it.
+      rc = HTTP_UNPROCESSABLE_ENTITY;
+      delete current_aor; current_aor = NULL;
+      break;
+    }
+    else
+    {
+      // Update the AoR with the requested changes.
+      current_aor->copy_aor(new_aor);
+      Store::Status store_rc = _aor_store->set_aor_data(aor_id,
+                                                        current_aor,
+                                                        current_aor->get_expiry(),
+                                                        trail);
+
+      if (store_rc == Store::Status::OK)
+      {
+        replicate_put_cross_site(aor_id, new_aor, trail);
+        rc = HTTP_OK;
+        break;
+      }
+      else if (store_rc == Store::Status::ERROR)
+      {
+        // Failed to add data - we don't try and add the subscriber to
+        // any remote sites.
+        TRC_DEBUG("Failed to add subscriber %s to %s",
+                  aor_id.c_str(),
+                  _id.c_str());
+        rc = HTTP_SERVER_ERROR;
+        break;
+      }
+    }
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_patch(std::string aor_id,
+                          PatchObject* po,
+                          SAS::TrailId trail)
+{
+  HTTPCode rc = HTTP_OK;
+
+  while (true)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL)
+    {
+      rc = HTTP_SERVER_ERROR;
+      break;
+    }
+    else if (aor->bindings().empty())
+    {
+      // We don't have data for this AoR, so we shouldn't have had a PATCH for it.
+      rc = HTTP_NOT_FOUND;
+      delete aor; aor = NULL;
+      break;
+    }
+    else
+    {
+      // Update the AoR with the requested changes.
+      aor->patch_aor(po);
+      Store::Status store_rc = _aor_store->set_aor_data(aor_id,
+                                                        aor,
+                                                        aor->get_expiry(),
+                                                        trail);
+
+      if (store_rc == Store::Status::OK)
+      {
+        replicate_patch_cross_site(aor_id, po, trail);
+        rc = HTTP_OK;
+        break;
+      }
+      else if (store_rc == Store::Status::ERROR)
+      {
+        // Failed to updateadd data - we don't try and update the subscriber in
+        // any remote sites.
+        TRC_DEBUG("Failed to update subscriber %s to %s",
+                  aor_id.c_str(),
+                  _id.c_str());
+        rc = HTTP_SERVER_ERROR;
+        break;
+      }
+    }
+  }
+
+  return rc;
+}
+
+void S4::replicate_delete_cross_site(std::string aor_id,
+                                     SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    remote_s4->handle_delete(aor_id, trail);
+  }
+}
+
+void S4::replicate_put_cross_site(std::string aor_id,
+                                  AoR* aor,
+                                  SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    HTTPCode rc = remote_s4->handle_put(aor_id, aor, trail);
+
+    if (rc == HTTP_UNPROCESSABLE_ENTITY)
+    {
+      // We've tried to do a PUT to a remote site that already has data. We need
+      // to send a PATCH instead.
+      TRC_DEBUG("Need to convert PUT to PATCH for %s", _id.c_str());
+      PatchObject* po = new PatchObject();
+      aor->convert_aor_to_patch(po);
+      remote_s4->handle_patch(aor_id, po, trail);
+    }
+  }
+}
+
+void S4::replicate_patch_cross_site(std::string aor_id,
+                                    PatchObject* po,
+                                    SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    HTTPCode rc = remote_s4->handle_patch(aor_id, po, trail);
+
+    if (rc == HTTP_UNPROCESSABLE_ENTITY)
+    {
+      // We've tried to do a PATCH to a remote site that doesn't have any data.
+      // We need to send a PUT.
+      TRC_DEBUG("Need to convert PATCH to PUT for %s", _id.c_str());
+      AoR* aor = new AoR(aor_id);
+      aor->convert_patch_to_aor(po);
+      remote_s4->handle_put(aor_id, aor, trail);
+    }
+  }
+}


### PR DESCRIPTION
Hi Ellie. These are the files that I think need to live in the S4 so that we can compile it outside of sprout. I don't think it's worth reviewing the files in detail (as they are mostly just moved from sprout), but could you check:

* The list of files that I've moved seems sensible to you?
* The interim solution for SAS logging (where I've created `include/s4sasevent.h` but not updated cpp-common or the resource bundle yet). 

I'm haven't actually tried compiling this outside of sprout, but I have checked the dependency files and there is nothing in them that refers to sprout or PJSIP. 