### PR TITLE
Remove some includes S4 does not depend on

### DIFF
--- a/include/s4.h
+++ b/include/s4.h
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include "sas.h"
-#include "analyticslogger.h"
 #include "associated_uris.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -29,8 +29,6 @@
 #include "utils.h"
 #include "s4.h"
 #include "astaire_aor_store.h"
-#include "sproutsasevent.h"
-#include "constants.h"
 
 // SDM-REFACTOR-TODO:
 // 1. Commonise logic in the handles? Or at least make more similar.


### PR DESCRIPTION
I've removed some dependencies that S4 had on sprout code (needed to build the FVs). 