### PR TITLE
Initialize fields in the Binding and Subscription objects

### DIFF
--- a/include/aor.h
+++ b/include/aor.h
@@ -52,7 +52,7 @@ static const char* const JSON_SCSCF_URI = "scscf-uri";
 class Binding
 {
 public:
-  Binding(std::string address_of_record): _address_of_record(address_of_record) {};
+  Binding(std::string address_of_record);
 
   /// The address of record, e.g. "sip:name@example.com".
   std::string _address_of_record;
@@ -127,7 +127,7 @@ typedef std::pair<std::string, Binding*> BindingPair;
 class Subscription
 {
 public:
-  Subscription(): _refreshed(false) {};
+  Subscription(): _refreshed(false), _expires(0) {};
 
   /// The Contact URI for the subscription dialog (used as the Request URI
   /// of the NOTIFY)

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -197,6 +197,15 @@ void AoR::clear_bindings()
 }
 
 
+Binding::Binding(std::string address_of_record) :
+  _address_of_record(address_of_record),
+  _cseq(0),
+  _expires(0),
+  _priority(0),
+  _emergency_registration(false)
+{}
+
+
 void Binding::
   to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
 {


### PR DESCRIPTION
This initializes some Plain Old Data fields which C++ does not initialize by default. This is needed to avoid potential non-deterministic behavior due to reading uninitialized data. This was spotted in clearwater-fv-test, and tested there as well. 