### PR TITLE
[Reviewer: Graeme] S4 changes

### DIFF
--- a/include/aor.h
+++ b/include/aor.h
@@ -116,6 +116,11 @@ public:
   void from_json(const rapidjson::Value& b_obj);
 };
 
+/// Typedef the map Bindings and the pair BindingPair. First is sometimes the
+/// contact URI, but not always. Second is a pointer to a Binding.
+typedef std::map<std::string, Binding*> Bindings;
+typedef std::pair<std::string, Binding*> BindingPair;
+
 /// @class Subscription
 ///
 /// Represents a subscription to registration events for the AoR.
@@ -171,6 +176,12 @@ public:
   void from_json(const rapidjson::Value& s_obj);
 };
 
+/// Typedef the map Subscriptions and the pair SubscriptionPair. First is
+/// sometimes the To tag, but not always. Second is a pointer to a
+/// Subscription.
+typedef std::map<std::string, Subscription*> Subscriptions;
+typedef std::pair<std::string, Subscription*> SubscriptionPair;
+
 // SDM-REFACTOR-TODO: prototype
 class PatchObject
 {
@@ -181,26 +192,26 @@ public:
   /// Destructor
   ~PatchObject();
 
-  inline std::map<std::string, Binding*> update_bindings() { return _update_bindings; }
+  inline Bindings update_bindings() { return _update_bindings; }
   inline std::vector<std::string> remove_bindings() { return _remove_bindings; }
-  inline std::map<std::string, Subscription*> update_subscriptions() { return _update_subscriptions; }
+  inline Subscriptions update_subscriptions() { return _update_subscriptions; }
   inline std::vector<std::string> remove_subscriptions() { return _remove_subscriptions; }
   inline AssociatedURIs associated_uris() { return _associated_uris; }
   inline int minimum_cseq() { return _minimum_cseq; }
   inline bool increment_cseq() { return _increment_cseq; }
 
-  inline void set_update_bindings(std::map<std::string, Binding*> bindings) { _update_bindings = bindings; }
+  inline void set_update_bindings(Bindings bindings) { _update_bindings = bindings; }
   inline void set_remove_bindings(std::vector<std::string> bindings) { _remove_bindings = bindings; }
-  inline void set_update_subscriptions(std::map<std::string, Subscription*> subscriptions) { _update_subscriptions = subscriptions; }
+  inline void set_update_subscriptions(Subscriptions subscriptions) { _update_subscriptions = subscriptions; }
   inline void set_remove_subscriptions(std::vector<std::string> subscriptions) { _remove_subscriptions = subscriptions; }
   inline void set_associated_uris(AssociatedURIs associated_uris) { _associated_uris = associated_uris; }
   inline void set_minimum_cseq(int minimum) { _minimum_cseq = minimum; }
   inline void set_increment_cseq(bool increment) { _increment_cseq = increment; }
 
 private:
-  std::map<std::string, Binding*> _update_bindings;
+  Bindings _update_bindings;
   std::vector<std::string> _remove_bindings;
-  std::map<std::string, Subscription*> _update_subscriptions;
+  Subscriptions _update_subscriptions;
   std::vector<std::string> _remove_subscriptions;
   AssociatedURIs _associated_uris;
   int _minimum_cseq;
@@ -248,13 +259,6 @@ public:
 
   // Remove the bindings from an AOR object
   void clear_bindings();
-
-  /// Binding ID -> Binding.  First is sometimes the contact URI, but not always.
-  /// Second is a pointer to an object owned by this object.
-  typedef std::map<std::string, Binding*> Bindings;
-
-  /// To tag -> Subscription.
-  typedef std::map<std::string, Subscription*> Subscriptions;
 
   /// Retrieve all the bindings.
   inline const Bindings& bindings() const { return _bindings; }
@@ -369,10 +373,10 @@ public:
 
   /// Utility functions to compare Bindings and Subscriptions in the original AoR
   /// and current AoR, and return the set of those created/updated or removed.
-  AoR::Bindings get_updated_bindings();
-  AoR::Subscriptions get_updated_subscriptions();
-  AoR::Bindings get_removed_bindings();
-  AoR::Subscriptions get_removed_subscriptions();
+  Bindings get_updated_bindings();
+  Subscriptions get_updated_subscriptions();
+  Bindings get_removed_bindings();
+  Subscriptions get_removed_subscriptions();
 
 private:
   AoR* _orig_aor;

--- a/include/aor.h
+++ b/include/aor.h
@@ -204,9 +204,9 @@ public:
   inline const int get_minimum_cseq() const { return _minimum_cseq; }
   inline const bool get_increment_cseq() const { return _increment_cseq; }
 
-  inline void set_update_bindings(std::map<std::string, Binding*> bindings) { _update_bindings = bindings; }
+  inline void set_update_bindings(Bindings bindings) { _update_bindings = bindings; }
   inline void set_remove_bindings(std::vector<std::string> bindings) { _remove_bindings = bindings; }
-  inline void set_update_subscriptions(std::map<std::string, Subscription*> subscriptions) { _update_subscriptions = subscriptions; }
+  inline void set_update_subscriptions(Subscriptions subscriptions) { _update_subscriptions = subscriptions; }
   inline void set_remove_subscriptions(std::vector<std::string> subscriptions) { _remove_subscriptions = subscriptions; }
   inline void set_associated_uris(AssociatedURIs associated_uris) { _associated_uris = associated_uris; }
   inline void set_minimum_cseq(int minimum) { _minimum_cseq = minimum; }
@@ -269,13 +269,6 @@ public:
 
   // Remove the bindings from an AOR object
   void clear_bindings();
-
-  /// Binding ID -> Binding.  First is sometimes the contact URI, but not always.
-  /// Second is a pointer to an object owned by this object.
-  typedef std::map<std::string, Binding*> Bindings;
-
-  /// To tag -> Subscription.
-  typedef std::map<std::string, Subscription*> Subscriptions;
 
   /// Retrieve all the bindings.
   inline const Bindings& bindings() const { return _bindings; }

--- a/include/aor.h
+++ b/include/aor.h
@@ -189,6 +189,14 @@ public:
   inline int minimum_cseq() { return _minimum_cseq; }
   inline bool increment_cseq() { return _increment_cseq; }
 
+  inline void set_update_bindings(std::map<std::string, Binding*> bindings) { _update_bindings = bindings; }
+  inline void set_remove_bindings(std::vector<std::string> bindings) { _remove_bindings = bindings; }
+  inline void set_update_subscriptions(std::map<std::string, Subscription*> subscriptions) { _update_subscriptions = subscriptions; }
+  inline void set_remove_subscriptions(std::vector<std::string> subscriptions) { _remove_subscriptions = subscriptions; }
+  inline void set_associated_uris(AssociatedURIs associated_uris) { _associated_uris = associated_uris; }
+  inline void set_minimum_cseq(int minimum) { _minimum_cseq = minimum; }
+  inline void set_increment_cseq(bool increment) { _increment_cseq = increment; }
+
 private:
   std::map<std::string, Binding*> _update_bindings;
   std::vector<std::string> _remove_bindings;

--- a/include/aor.h
+++ b/include/aor.h
@@ -172,17 +172,31 @@ public:
 };
 
 // SDM-REFACTOR-TODO: prototype
-struct PatchObject
+class PatchObject
 {
-  PatchObject() : _increment(false) {}
+public:
+  // Constructor
+  PatchObject();
 
-  std::vector<Binding> _bindings_to_update;
-  std::vector<std::string> _bindings_to_remove;
-  Subscription _subscription_to_update;
-  std::string _subscription_to_remove;
+  /// Destructor
+  ~PatchObject();
+
+  inline std::map<std::string, Binding*> update_bindings() { return _update_bindings; }
+  inline std::vector<std::string> remove_bindings() { return _remove_bindings; }
+  inline std::map<std::string, Subscription*> update_subscriptions() { return _update_subscriptions; }
+  inline std::vector<std::string> remove_subscriptions() { return _remove_subscriptions; }
+  inline AssociatedURIs associated_uris() { return _associated_uris; }
+  inline int minimum_cseq() { return _minimum_cseq; }
+  inline bool increment_cseq() { return _increment_cseq; }
+
+private:
+  std::map<std::string, Binding*> _update_bindings;
+  std::vector<std::string> _remove_bindings;
+  std::map<std::string, Subscription*> _update_subscriptions;
+  std::vector<std::string> _remove_subscriptions;
   AssociatedURIs _associated_uris;
-  int _min_cseq;
-  bool _increment;
+  int _minimum_cseq;
+  bool _increment_cseq;
 };
 
 /// @class AoR
@@ -258,8 +272,9 @@ public:
   void copy_aor(AoR* source_aor);
 
   // SDM-REFACTOR-TODO: Implement/comment/test
-  int get_expiry() { return 1; }
-  void patch_aor(PatchObject* po) {};
+  void get_next_and_last_expires(int& next_expires, int& last_expires);
+  void patch_aor(PatchObject* po);
+
   void convert_aor_to_patch(PatchObject* po) {};
   void convert_patch_to_aor(PatchObject* po) {};
 

--- a/include/aor.h
+++ b/include/aor.h
@@ -1,0 +1,357 @@
+/**
+ * @file aor.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef AOR_H__
+#define AOR_H__
+
+#include <string>
+#include <list>
+#include <map>
+#include <stdio.h>
+#include <stdlib.h>
+#include "rapidjson/writer.h"
+#include "rapidjson/document.h"
+#include "associated_uris.h"
+
+/// JSON serialization constants.
+/// These live here, as the core logic of serialization lives in the AoR
+/// to_json methods, but the SDM also uses some of them.
+static const char* const JSON_BINDINGS = "bindings";
+static const char* const JSON_CID = "cid";
+static const char* const JSON_CSEQ = "cseq";
+static const char* const JSON_EXPIRES = "expires";
+static const char* const JSON_PRIORITY = "priority";
+static const char* const JSON_PARAMS = "params";
+static const char* const JSON_PATHS = "paths"; // Depracated as of PC release 119. SDM-REFACTOR-TODO: No longer needed. Delete.
+static const char* const JSON_PATH_HEADERS = "path_headers";
+static const char* const JSON_TIMER_ID = "timer_id";
+static const char* const JSON_PRIVATE_ID = "private_id";
+static const char* const JSON_EMERGENCY_REG = "emergency_reg";
+static const char* const JSON_SUBSCRIPTIONS = "subscriptions";
+static const char* const JSON_REQ_URI = "req_uri";
+static const char* const JSON_FROM_URI = "from_uri";
+static const char* const JSON_FROM_TAG = "from_tag";
+static const char* const JSON_TO_URI = "to_uri";
+static const char* const JSON_TO_TAG = "to_tag";
+static const char* const JSON_ROUTES = "routes";
+static const char* const JSON_NOTIFY_CSEQ = "notify_cseq";
+static const char* const JSON_SCSCF_URI = "scscf-uri";
+
+/// @class Binding
+///
+/// A single registered address.
+class Binding
+{
+public:
+  Binding(std::string address_of_record): _address_of_record(address_of_record) {};
+
+  /// The address of record, e.g. "sip:name@example.com".
+  std::string _address_of_record;
+
+  /// The registered contact URI, e.g.,
+  /// "sip:2125551212@192.168.0.1:55491;transport=TCP;rinstance=fad34fbcdea6a931"
+  std::string _uri;
+
+  /// The Call-ID: of the registration.  Per RFC3261, this is the same for
+  /// all registrations from a given UAC to this registrar (for this AoR).
+  /// E.g., "gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq"
+  std::string _cid;
+
+  /// Contains any path headers (in order) that were present on the
+  /// register.  Empty if there were none. This is the full path header,
+  /// including the disply name, URI and any header parameters.
+  std::list<std::string> _path_headers;
+
+  /// Contains the URI part of any path headers (in order) that were
+  /// present on the register. Empty if there were none.
+  std::list<std::string> _path_uris;
+
+  /// The CSeq value of the REGISTER request.
+  int _cseq;
+
+  /// The time (in seconds since the epoch) at which this binding should
+  /// expire.  Based on the expires parameter of the Contact: header.
+  int _expires;
+
+  /// The Contact: header q parameter (qvalue), times 1000.  This is used
+  /// to prioritise the registrations (highest value first), per RFC3261
+  /// s10.2.1.2.
+  int _priority;
+
+  /// Any other parameters found in the Contact: header, stored as key ->
+  /// value.  E.g., "+sip.ice" -> "".
+  std::map<std::string, std::string> _params;
+
+  /// The private ID this binding was registered with.
+  std::string _private_id;
+
+  /// Whether this is an emergency registration.
+  bool _emergency_registration;
+
+  /// Serialize the binding as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+  // Deserialize a binding from a JSON object.
+  //
+  // @param b_obj - The binding as a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& b_obj);
+};
+
+/// @class Subscription
+///
+/// Represents a subscription to registration events for the AoR.
+class Subscription
+{
+public:
+  Subscription(): _refreshed(false) {};
+
+  /// The Contact URI for the subscription dialog (used as the Request URI
+  /// of the NOTIFY)
+  std::string _req_uri;
+
+  /// The From URI for the subscription dialog (used in the to header of
+  /// the NOTIFY)
+  std::string _from_uri;
+
+  /// The From tag for the subscription dialog.
+  std::string _from_tag;
+
+  /// The To URI for the subscription dialog.
+  std::string _to_uri;
+
+  /// The To tag for the subscription dialog.
+  std::string _to_tag;
+
+  /// The call ID for the subscription dialog.
+  std::string _cid;
+
+  /// Whether the subscription has been refreshed since the last NOTIFY.
+  bool _refreshed;
+
+  /// The list of Record Route URIs from the subscription dialog.
+  std::list<std::string> _route_uris;
+
+  /// The time (in seconds since the epoch) at which this subscription
+  /// should expire.
+  int _expires;
+
+  /// Serialize the subscription as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+  // Deserialize a subscription from a JSON object.
+  //
+  // @param s_obj - The subscription as a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& s_obj);
+};
+
+// SDM-REFACTOR-TODO: prototype
+struct PatchObject
+{
+  PatchObject() : _increment(false) {}
+
+  std::vector<Binding> _bindings_to_update;
+  std::vector<std::string> _bindings_to_remove;
+  Subscription _subscription_to_update;
+  std::string _subscription_to_remove;
+  AssociatedURIs _associated_uris;
+  int _min_cseq;
+  bool _increment;
+};
+
+/// @class AoR
+///
+/// Addresses that are registered for this address of record.
+class AoR
+{
+public:
+  /// Default Constructor.
+  AoR(std::string sip_uri);
+
+  /// Destructor.
+  ~AoR();
+
+  /// Make sure copy is deep!
+  AoR(const AoR& other);
+
+  // Make sure assignment is deep!
+  AoR& operator= (AoR const& other);
+
+  // Common code between copy and assignment
+  void common_constructor(const AoR& other);
+
+  /// Clear all the bindings and subscriptions from this object.
+  void clear(bool clear_emergency_bindings);
+
+  /// Retrieve a binding by Binding ID, creating an empty one if necessary.
+  /// The created binding is completely empty, even the Contact URI field.
+  Binding* get_binding(const std::string& binding_id);
+
+  /// Removes any binding that had the given ID.  If there is no such binding,
+  /// does nothing.
+  void remove_binding(const std::string& binding_id);
+
+  /// Retrieve a subscription by To tag, creating an empty one if necessary.
+  Subscription* get_subscription(const std::string& to_tag);
+
+  /// Remove a subscription for the specified To tag.  If there is no
+  /// corresponding subscription does nothing.
+  void remove_subscription(const std::string& to_tag);
+
+  // Remove the bindings from an AOR object
+  void clear_bindings();
+
+  /// Binding ID -> Binding.  First is sometimes the contact URI, but not always.
+  /// Second is a pointer to an object owned by this object.
+  typedef std::map<std::string, Binding*> Bindings;
+
+  /// To tag -> Subscription.
+  typedef std::map<std::string, Subscription*> Subscriptions;
+
+  /// Retrieve all the bindings.
+  inline const Bindings& bindings() const { return _bindings; }
+
+  /// Retrieve all the subscriptions.
+  inline const Subscriptions& subscriptions() const { return _subscriptions; }
+
+  // Return the number of bindings in the AoR.
+  inline uint32_t get_bindings_count() const { return _bindings.size(); }
+
+  // Return the number of subscriptions in the AoR.
+  inline uint32_t get_subscriptions_count() const { return _subscriptions.size(); }
+
+  // Return the expiry time of the binding or subscription due to expire next.
+  int get_next_expires();
+
+  /// Copy all site agnostic values from one AoR to this AoR. This copies basically
+  /// everything, but importantly not the CAS. It doesn't remove any bindings
+  /// or subscriptions that may have been in the existing AoR but not in the copied
+  /// AoR.
+  ///
+  /// @param source_aor           Source AoR for the copy
+  void copy_aor(AoR* source_aor);
+
+  // SDM-REFACTOR-TODO: Implement/comment/test
+  int get_expiry() { return 1; }
+  void patch_aor(PatchObject* po) {};
+  void convert_aor_to_patch(PatchObject* po) {};
+  void convert_patch_to_aor(PatchObject* po) {};
+
+  /// CSeq value for event notifications for this AoR.  This is initialised
+  /// to one when the AoR record is first set up and incremented every time
+  /// the record is updated while there are active subscriptions.  (It is
+  /// sufficient to use the same CSeq for each NOTIFY sent on each active
+  /// because there is no requirement that the first NOTIFY in a dialog has
+  /// CSeq=1, and once a subscription dialog is established it should
+  /// receive every NOTIFY for the AoR.)
+  int _notify_cseq;
+
+  // Chronos Timer ID
+  std::string _timer_id;
+
+  /// S-CSCF URI name for this AoR. This is used on the SAR if the
+  /// registration expires. This field should not be changed once the
+  /// registration has been created.
+  std::string _scscf_uri;
+
+  /// Map holding the bindings for a particular AoR indexed by binding ID.
+  Bindings _bindings;
+
+  /// Map holding the subscriptions for this AoR, indexed by the To tag
+  /// generated when the subscription dialog was established.
+  Subscriptions _subscriptions;
+
+  // Associated URIs class, to hold the associated URIs for this IRS.
+  AssociatedURIs _associated_uris;
+
+  /// CAS value for this AoR record.  Used when updating an existing record.
+  /// Zero for a new record that has not yet been written to a store.
+  uint64_t _cas;
+
+  // SIP URI for this AoR
+  std::string _uri;
+
+  /// Store code is allowed to manipulate bindings and subscriptions directly.
+  friend class AoRStore;
+  friend class SubscriberDataManager;
+};
+
+/// @class AoRPair
+///
+/// Class to hold a pair of AoRs. The original AoR holds the AoR retrieved
+/// from the store, the current AoR holds any changes made to the AoR before
+/// it's put back in the store
+class AoRPair
+{
+public:
+  AoRPair(std::string aor_id)
+  {
+    _orig_aor = new AoR(aor_id);
+    _current_aor = new AoR(aor_id);
+  }
+
+  AoRPair(AoR* orig_aor, AoR* current_aor):
+    _orig_aor(orig_aor),
+    _current_aor(current_aor)
+  {}
+
+  ~AoRPair()
+  {
+    delete _orig_aor; _orig_aor = NULL;
+    delete _current_aor; _current_aor = NULL;
+  }
+
+  /// Get the current AoR
+  AoR* get_current() { return _current_aor; }
+
+  /// Does the current AoR contain any bindings?
+  bool current_contains_bindings()
+  {
+    return ((_current_aor != NULL) &&
+            (!_current_aor->_bindings.empty()));
+  }
+
+  /// Does the current AoR contain any subscriptions?
+  bool current_contains_subscriptions()
+  {
+    return ((_current_aor != NULL) &&
+            (!_current_aor->subscriptions().empty()));
+  }
+
+  /// Utility functions to compare Bindings and Subscriptions in the original AoR
+  /// and current AoR, and return the set of those created/updated or removed.
+  AoR::Bindings get_updated_bindings();
+  AoR::Subscriptions get_updated_subscriptions();
+  AoR::Bindings get_removed_bindings();
+  AoR::Subscriptions get_removed_subscriptions();
+
+private:
+  AoR* _orig_aor;
+  AoR* _current_aor;
+
+  /// Get the original AoR
+  AoR* get_orig() { return _orig_aor; }
+
+  /// The subscriber data manager is allowed to access the original AoR
+  friend class SubscriberDataManager;
+};
+
+#endif

--- a/include/aor.h
+++ b/include/aor.h
@@ -192,23 +192,33 @@ public:
   /// Destructor
   ~PatchObject();
 
-  inline Bindings update_bindings() { return _update_bindings; }
-  inline std::vector<std::string> remove_bindings() { return _remove_bindings; }
-  inline Subscriptions update_subscriptions() { return _update_subscriptions; }
-  inline std::vector<std::string> remove_subscriptions() { return _remove_subscriptions; }
-  inline AssociatedURIs associated_uris() { return _associated_uris; }
-  inline int minimum_cseq() { return _minimum_cseq; }
-  inline bool increment_cseq() { return _increment_cseq; }
+  /// Make sure copy is deep!
+  PatchObject(const PatchObject& other);
+  PatchObject& operator= (PatchObject const& other);
 
-  inline void set_update_bindings(Bindings bindings) { _update_bindings = bindings; }
+  inline const Bindings get_update_bindings() const { return _update_bindings; }
+  inline const std::vector<std::string> get_remove_bindings() const { return _remove_bindings; }
+  inline const Subscriptions get_update_subscriptions() const { return _update_subscriptions; }
+  inline const std::vector<std::string> get_remove_subscriptions() const { return _remove_subscriptions; }
+  inline const AssociatedURIs get_associated_uris() const { return _associated_uris; }
+  inline const int get_minimum_cseq() const { return _minimum_cseq; }
+  inline const bool get_increment_cseq() const { return _increment_cseq; }
+
+  inline void set_update_bindings(std::map<std::string, Binding*> bindings) { _update_bindings = bindings; }
   inline void set_remove_bindings(std::vector<std::string> bindings) { _remove_bindings = bindings; }
-  inline void set_update_subscriptions(Subscriptions subscriptions) { _update_subscriptions = subscriptions; }
+  inline void set_update_subscriptions(std::map<std::string, Subscription*> subscriptions) { _update_subscriptions = subscriptions; }
   inline void set_remove_subscriptions(std::vector<std::string> subscriptions) { _remove_subscriptions = subscriptions; }
   inline void set_associated_uris(AssociatedURIs associated_uris) { _associated_uris = associated_uris; }
   inline void set_minimum_cseq(int minimum) { _minimum_cseq = minimum; }
   inline void set_increment_cseq(bool increment) { _increment_cseq = increment; }
 
 private:
+  // Common code between copy and assignment
+  void common_constructor(const PatchObject& other);
+
+  /// Clear all the bindings and subscriptions from this object.
+  void clear();
+
   Bindings _update_bindings;
   std::vector<std::string> _remove_bindings;
   Subscriptions _update_subscriptions;
@@ -260,6 +270,13 @@ public:
   // Remove the bindings from an AOR object
   void clear_bindings();
 
+  /// Binding ID -> Binding.  First is sometimes the contact URI, but not always.
+  /// Second is a pointer to an object owned by this object.
+  typedef std::map<std::string, Binding*> Bindings;
+
+  /// To tag -> Subscription.
+  typedef std::map<std::string, Subscription*> Subscriptions;
+
   /// Retrieve all the bindings.
   inline const Bindings& bindings() const { return _bindings; }
 
@@ -275,6 +292,18 @@ public:
   // Return the expiry time of the binding or subscription due to expire next.
   int get_next_expires();
 
+  /// get_last_expires
+  ///
+  /// This returns the expiry time of the binding or subscription due to expire
+  /// last.
+  /// The expiry time is relative, so if this was called on an AoR containing a
+  /// single binding due to expire in 1 minute it would return 60.
+  /// This can be called on a empty AoR, where it will return 0.
+  ///
+  /// @return Return the expiry time of the binding or subscription due to
+  ///         expire last.
+  int get_last_expires() const;
+
   /// Copy all site agnostic values from one AoR to this AoR. This copies basically
   /// everything, but importantly not the CAS. It doesn't remove any bindings
   /// or subscriptions that may have been in the existing AoR but not in the copied
@@ -284,9 +313,7 @@ public:
   void copy_aor(AoR* source_aor);
 
   // SDM-REFACTOR-TODO: Implement/comment/test
-  void get_next_and_last_expires(int& next_expires, int& last_expires);
-  void patch_aor(PatchObject* po);
-
+  void patch_aor(const PatchObject& po);
   void convert_aor_to_patch(PatchObject* po) {};
   void convert_patch_to_aor(PatchObject* po) {};
 

--- a/include/aor.h
+++ b/include/aor.h
@@ -57,6 +57,8 @@ public:
   /// The address of record, e.g. "sip:name@example.com".
   std::string _address_of_record;
 
+  /// This is the binding ID. SDM-REFACTOR-TODO: Actually it might not always be.
+  /// See get_binding_id() in registrarsproutlet.cpp
   /// The registered contact URI, e.g.,
   /// "sip:2125551212@192.168.0.1:55491;transport=TCP;rinstance=fad34fbcdea6a931"
   std::string _uri;
@@ -96,6 +98,9 @@ public:
 
   /// Whether this is an emergency registration.
   bool _emergency_registration;
+
+  /// Returns the ID of this binding.
+  std::string get_id() const { return _uri; }
 
   /// Serialize the binding as a JSON object.
   ///
@@ -148,6 +153,9 @@ public:
   /// The time (in seconds since the epoch) at which this subscription
   /// should expire.
   int _expires;
+
+  /// Returns the ID of this subscription.
+  std::string get_id() const { return _to_tag; }
 
   /// Serialize the subscription as a JSON object.
   ///

--- a/include/aor.h
+++ b/include/aor.h
@@ -52,7 +52,7 @@ static const char* const JSON_SCSCF_URI = "scscf-uri";
 class Binding
 {
 public:
-  Binding(std::string address_of_record): _address_of_record(address_of_record) {};
+  Binding(std::string address_of_record);
 
   /// The address of record, e.g. "sip:name@example.com".
   std::string _address_of_record;
@@ -127,7 +127,7 @@ typedef std::pair<std::string, Binding*> BindingPair;
 class Subscription
 {
 public:
-  Subscription(): _refreshed(false) {};
+  Subscription(): _refreshed(false), _expires(0) {};
 
   /// The Contact URI for the subscription dialog (used as the Request URI
   /// of the NOTIFY)

--- a/include/aor_store.h
+++ b/include/aor_store.h
@@ -1,0 +1,62 @@
+/**
+ * @file aor_store.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef AOR_STORE_H__
+#define AOR_STORE_H__
+
+
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#include "store.h"
+#include "aor.h"
+
+// Pure virtual parent class for implementations of the AoRStore, for use
+// in the SubscriberDataManager. Defines the public interface that must
+// be implemented in any derived classes.
+class AoRStore
+{
+public:
+  /// AoRSore constructor.
+  AoRStore(){}
+
+  /// Destructor.
+  virtual ~AoRStore(){}
+
+  // Called through to from handlers code.
+  virtual bool has_servers() = 0;
+
+  /// Get the data for a particular address of record (registered SIP URI,
+  /// in format "sip:2125551212@example.com"), creating it if necessary.
+  /// May return NULL in case of error.  Result is owned
+  /// by caller and must be freed with delete.
+  ///
+  /// @param aor_id    The AoR to retrieve
+  /// @param trail     SAS trail
+  virtual AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail) = 0;
+
+  /// Update the data for a particular address of record.
+  /// if the update succeeds, this returns true.
+  ///
+  /// @param aor_id               The AoR ID to set
+  /// @param aor_pair             The AoR pair to set data from
+  /// @param expiry               The expiry time associated with the AoR
+  /// @param trail                SAS trail
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* aor,
+                                     int expiry,
+                                     SAS::TrailId trail) = 0;
+};
+
+#endif

--- a/include/associated_uris.h
+++ b/include/associated_uris.h
@@ -1,0 +1,96 @@
+/**
+ * @file associated_uris.h Definitions for AssociatedURIs class.
+ *
+ * Copyright (C) Metaswitch Networks
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef ASSOCIATED_URIS_H_
+#define ASSOCIATED_URIS_H_
+
+#include <string>
+#include <vector>
+#include <map>
+#include "rapidjson/writer.h"
+#include "rapidjson/document.h"
+
+/// JSON Serialization constants
+static const char* const JSON_URI = "uri";
+static const char* const JSON_URIS = "uris";
+static const char* const JSON_BARRING = "barring";
+static const char* const JSON_WILDCARD_MAPPING ="wildcard-mapping";
+static const char* const JSON_ASSOCIATED_URIS = "associated-uris";
+static const char* const JSON_DISTINCT = "distinct";
+static const char* const JSON_WILDCARD = "wildcard";
+
+struct AssociatedURIs
+{
+public:
+  /// Gets sthe default IMPU from an implicit registration set.
+  bool get_default_impu(std::string& uri,
+                        bool emergency);
+
+  /// Checks if a URI is in the list of assiated URIs.
+  bool contains_uri(std::string uri);
+
+  /// Adds to the list of associated URIs.
+  void add_uri(std::string uri, bool barred);
+
+  /// Adds the barring status of a URI.
+  void add_barring_status(std::string uri, bool barred);
+
+  /// Clears this structure.
+  void clear_uris();
+
+  /// Returns whether a URI is barred or not.
+  bool is_impu_barred(std::string uri);
+
+  /// Returns all the unbarred URIs.
+  std::vector<std::string> get_unbarred_uris();
+
+  /// Returns all the barred URIs.
+  std::vector<std::string> get_barred_uris();
+
+  /// Returns all URIs.
+  std::vector<std::string> get_all_uris();
+
+  /// Returns the wildcard mappings.
+  std::map<std::string, std::string> get_wildcard_mapping();
+
+  /// Add a mapping between a distinct IMPU and the wildcard it belongs to
+  void add_wildcard_mapping(std::string wildcard, std::string distinct);
+
+  /// Serialize the associated URIs as a JSON object.
+  ///
+  /// @param writer - a rapidjson writer to write to.
+  void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer);
+
+  // Deserialize associated URIs from a JSON object.
+  //
+  // @param s_obj - The associated URIs a JSON object.
+  //
+  // @return      - Nothing. If this function fails (because the JSON is not
+  //                semantically valid) this method throws JsonFormError.
+  void from_json(const rapidjson::Value& s_obj);
+
+  // Compares the contents of this class instance to another, to see
+  // if they are the same.
+  bool operator==(AssociatedURIs associated_uris_other);
+  bool operator!=(AssociatedURIs associated_uris_other);
+
+private:
+  /// A vector of associated URIs.
+  std::vector<std::string> _associated_uris;
+
+  /// A map from the associated URIs to their barring state.
+  std::map<std::string, bool> _barred_map;
+
+  /// A map of distinct IMPUs to their wildcards
+  std::map<std::string, std::string> _distinct_to_wildcard;
+};
+
+#endif

--- a/include/astaire_aor_store.h
+++ b/include/astaire_aor_store.h
@@ -1,0 +1,118 @@
+/**
+ * @file astaire_aor_store.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef ASTAIRE_AOR_STORE_H__
+#define ASTAIRE_AOR_STORE_H__
+
+
+#include <string>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#include "aor_store.h"
+
+// Implementation of the AoRStore specific to our use of Memcached under Astaire
+class AstaireAoRStore: public AoRStore
+{
+public:
+  /// Constructor.
+  AstaireAoRStore(Store* store);
+
+  /// Destructor.
+  virtual ~AstaireAoRStore();
+
+  // Called through to from handlers code.
+  virtual bool has_servers() override { return _connector->underlying_store_has_servers(); }
+
+  /// Get the data for a particular address of record (registered SIP URI,
+  /// in format "sip:2125551212@example.com"), creating it if necessary.
+  /// May return NULL in case of error.  Result is owned
+  /// by caller and must be freed with delete.
+  ///
+  /// @param aor_id    The AoR to retrieve
+  /// @param trail     SAS trail
+  virtual AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail) override;
+
+  /// Update the data for a particular address of record.
+  /// if the update succeeds, this returns true.
+  ///
+  /// @param aor_id               The AoR ID to set
+  /// @param aor_pair             The AoR pair to set data from
+  /// @param expiry               The expiry time associated with the AoR
+  /// @param trail                SAS trail
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* aor,
+                                     int expiry,
+                                     SAS::TrailId trail) override;
+
+
+  /// Class used by the AstaireAoRStore to serialize AoRs from C++
+  /// objects to the JSON format used in the store, and deserialize them.
+  class JsonSerializerDeserializer
+  {
+  public:
+    /// Destructor.
+    ~JsonSerializerDeserializer() {}
+
+    /// Serialize an AoR object to the format used in the store.
+    ///
+    /// @param aor_data - The AoR object to serialize.
+    /// @return         - The serialized form.
+    std::string serialize_aor(AoR* aor_data);
+
+    /// Deserialize some data from the store into an AoR object.
+    ///
+    /// @param aor_id - The primary public ID for the AoR. This is also the key
+    ///                 used used for the record in the store.
+    /// @param s      - The data to deserialize.
+    ///
+    /// @return       - An AoR object, or NULL if the data could not be
+    ///                 deserialized (e.g. because it is corrupt).
+    AoR* deserialize_aor(const std::string& aor_id,
+                         const std::string& s);
+  };
+
+  /// Provides the interface to the data store. This is responsible for
+  /// updating and getting information from the underlying data store. The
+  /// classes that call this class are responsible for retrying the get/set
+  /// functions in case of failure.
+  class Connector
+  {
+    Connector(Store* data_store,
+              JsonSerializerDeserializer*& serializer_deserializer);
+
+    ~Connector();
+
+    AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail);
+
+    Store::Status set_aor_data(const std::string& aor_id,
+                               AoR* aor_data,
+                               int expiry,
+                               SAS::TrailId trail);
+
+    bool underlying_store_has_servers() { return (_data_store != NULL) && _data_store->has_servers(); }
+
+    Store* _data_store;
+
+    /// AstaireAoRStore is the only class that can use Connector
+    friend class AstaireAoRStore;
+
+  private:
+    JsonSerializerDeserializer* _serializer_deserializer;
+  };
+
+public:
+  Connector* _connector;
+};
+
+#endif

--- a/include/s4.h
+++ b/include/s4.h
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include "sas.h"
-#include "analyticslogger.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"
 

--- a/include/s4.h
+++ b/include/s4.h
@@ -202,7 +202,7 @@ public:
                                 SAS::TrailId trail);
 
   /// This deletes the subscriber from the local site. This should only be
-  /// called from another S4, not a client. the deployment.
+  /// called from another S4, not a client.
   ///
   /// @param id[in]    - The ID of the subscriber. This must be the default
   ///                    public identity.

--- a/include/s4.h
+++ b/include/s4.h
@@ -27,54 +27,228 @@
 class S4
 {
 public:
-  /// S4 constructor.
+  /// S4 constructor
   ///
-  /// @param aor_store          - Pointer to the underlying data store interface
+  /// @param id[in]           - Site name of the S4. This is only used in logs.
+  /// @param callback_uri[in] - Hostname that resolves to the S4s in the local
+  ///                           site. Used as the Chronos callback URI.
+  /// @param aor_store[in]    - Pointer to the underlying data store interface
+  /// @param remote_s4s[in]   - Pointers to all the remote S4s. If a remote S4
+  ///                           is created then this is an empty vector.
   S4(std::string id,
+     std::string callback_url,
      AoRStore* aor_store,
      std::vector<S4*> remote_s4s);
 
   /// Destructor.
+  ///
+  /// S4 doesn't own the memory for its pointer member variables, so there's
+  /// nothing to do to clean up.
   virtual ~S4();
 
-  virtual HTTPCode handle_get(std::string aor_id,
+  /// This sends a request to S4 to get the data for a subscriber. This looks
+  /// in the local store. If the local store returns NOT_FOUND, this asks the
+  /// remote S4s. If a remote S4 has data, this writes that data back into the
+  /// local store, and stops querying any other remote S4s. If a remote S4
+  /// query fails for any reason, this is logged, but otherwise ignored (it
+  /// doesn't impact the return code for the client call). If the data is
+  /// successfully retrieved then S4 gives the data a version number as well.
+  ///
+  /// @param id[in]       - The ID of the subscriber. This must be the default
+  ///                       public identity.
+  /// @param aor[out]     - The retrieved data. This is only valid if the return
+  ///                       code is Store::Status::OK. The caller must delete
+  ///                       the AoR.
+  /// @param version[out] - The version of the retrieved AoR.
+  /// @param trail[in]    - The SAS trail ID
+  ///
+  /// @return Whether any data has been retrieved. This can be one of:
+  ///   OK - The AoR was successfully retrieved.
+  ///   NOT_FOUND - The subscriber has no stored data on any contactable site.
+  ///   SERVER_ERROR - We failed to contact the local store; the subscriber
+  ///                  information is unknown.
+  virtual HTTPCode handle_get(const std::string& id,
                               AoR** aor,
                               uint64_t& version,
                               SAS::TrailId trail);
-  virtual HTTPCode handle_local_delete(std::string aor_id,
-                                       uint64_t cas,
-                                       SAS::TrailId trail);
-  virtual HTTPCode handle_remote_delete(std::string aor_id,
-                                        SAS::TrailId trail);
-  virtual HTTPCode handle_put(std::string aor_id,
-                              AoR* aor,
-                              SAS::TrailId id);
 
-  virtual HTTPCode handle_patch(std::string aor_id,
-                                PatchObject* po,
+  /// This deletes the subscriber from the deployment. The delete takes a
+  /// version - if the current subscriber data has a different version than
+  /// the passed in version the delete fails. The subscriber is deleted from
+  /// all contactable sites, the return code of this function only depends
+  /// on whether the subscriber was deleted from the local site though.
+  ///
+  /// @param id[in]      - The ID of the subscriber. This must be the default
+  ///                      public identity.
+  /// @param version[in] - The version of the subscriber data that this is
+  ///                      asking to delete.
+  /// @param trail[in]   - The SAS trail ID
+  ///
+  /// @return Whether the data has been deleted. This can be one of:
+  ///   NO_CONTENT - The AoR was successfully deleted from at least the local
+  ///                site (or wasn't present in the first place).
+  ///   PRECONDITION_FAILED - The current version of the subscriber's data is
+  ///                         different to the version that the client has
+  ///                         asked to delete. The versions must be the same.
+  ///   SERVER_ERROR - We failed to contact the local store; the subscriber
+  ///                  information is unknown.
+  virtual HTTPCode handle_delete(const std::string& id,
+                                 uint64_t version,
+                                 SAS::TrailId trail);
+
+  /// This adds a subscriber to the deployment. This only succeeds if the
+  /// subscriber doesn't already exist. The subscriber is added to all
+  /// contactable sites, the return code of this function only depends on
+  /// whether the subscriber was added to the local site though.
+  ///
+  /// @param id[in]  - The ID of the subscriber. This must be the default
+  ///                  public identity.
+  /// @param aor[in] - The AoR object to update the subscriber with.
+  /// @param trail   - The SAS trail ID
+  ///
+  /// @return Whether the data has been deleted. This can be one of:
+  ///   OK - The AoR was successfully deleted from at least the local site
+  ///       (or wasn't present in the first place).
+  ///   PRECONDITION_FAILED - The subscriber already exists.
+  ///   SERVER_ERROR - We failed to contact the local store; the subscriber
+  ///                  information is unknown.
+  virtual HTTPCode handle_put(const std::string& id,
+                              const AoR& aor,
+                              SAS::TrailId trail);
+
+  /// This updates a subscriber in the deployment. This only succeeds if the
+  /// subscriber already exists. The subscriber is updated in all contactable
+  /// sites, the return code of this function only depends on whether the
+  /// subscriber was updated in the local site though.
+  ///
+  /// @param id[in]   - The ID of the subscriber. This must be the default
+  ///                   public identity.
+  /// @param po[in]   - The patch object to patch and update the subscriber
+  ///                   with.
+  /// @param aor[out] - The retrieved data. This is only valid if the return
+  ///                   code is HTTP_OK. The caller must delete the AoR.
+  /// @param trail    - The SAS trail ID
+  ///
+  /// @return Whether the data has been deleted. This can be one of:
+  ///   OK - The AoR was successfully deleted from at least the local site
+  ///       (or wasn't present in the first place).
+  ///   NOT_FOUND - The subscriber doesn't exist, so can't be patched.
+  ///   SERVER_ERROR - We failed to contact the local store; the subscriber
+  ///                  information is unknown.
+  virtual HTTPCode handle_patch(const std::string& id,
+                                const PatchObject& po,
                                 AoR** aor,
                                 SAS::TrailId trail);
 
-  std::string get_id() { return _id; }
+  /// This deletes the subscriber from the local site. This should only be
+  /// called from another S4, not a client. the deployment.
+  ///
+  /// @param id[in]    - The ID of the subscriber. This must be the default
+  ///                    public identity.
+  /// @param trail[in] - The SAS trail ID
+  ///
+  /// @return Whether the data has been deleted. This can be one of:
+  ///   NO_CONTENT - The AoR was successfully deleted from the local site (or
+  ///                wasn't present in the first place).
+  ///   SERVER_ERROR - We failed to contact the local store; the subscriber
+  ///                  information is unknown.
+  virtual void handle_remote_delete(const std::string& id,
+                                    SAS::TrailId trail);
+
 private:
-  void replicate_delete_cross_site(std::string aor_id,
+  /// This replicates a DELETE request from a client to the remote S4s. This
+  /// doesn't return anything as the local S4 won't do anything if any
+  /// remote delete fails (this function handles the different failure cases
+  /// itself).
+  ///
+  /// @param id[in]    - The ID of the subscriber. This must be the default
+  ///                    public identity.
+  /// @param trail[in] - The SAS trail ID
+  void replicate_delete_cross_site(const std::string& aor_id,
                                    SAS::TrailId trail);
-  void replicate_patch_cross_site(std::string aor_id,
-                                  PatchObject* po,
+
+  /// This replicates a PATCH request from a client to the remote S4s. This
+  /// doesn't return anything as the local S4 won't do anything if any
+  /// remote patch fails (this function handles the different failure cases
+  /// itself).
+  ///
+  /// @param id[in]    - The ID of the subscriber. This must be the default
+  ///                    public identity.
+  /// @param po[in]    - The patch object to patch and update the subscriber
+  ///                    with.
+  /// @param trail[in] - The SAS trail ID
+  void replicate_patch_cross_site(const std::string& aor_id,
+                                  const PatchObject& po,
                                   SAS::TrailId trail);
-  void replicate_put_cross_site(std::string aor_id,
-                                AoR* aor,
+
+  /// This replicates a PUT request from a client to the remote S4s. This
+  /// doesn't return anything as the local S4 won't do anything if any
+  /// remote puts fails (this function handles the different failure cases
+  /// itself).
+  ///
+  /// @param id[in]    - The ID of the subscriber. This must be the default
+  ///                    public identity.
+  /// @param aor[in]   - The AoR object to update the subscriber with.
+  /// @param trail[in] - The SAS trail ID
+  void replicate_put_cross_site(const std::string& id,
+                                const AoR& aor,
                                 SAS::TrailId trail);
 
+  /// This gets data from memcached (calling into the underlying data store),
+  /// and returns whether the get was successful. This only calls into the local
+  /// store.
+  ///
+  /// @param id[in]    - The ID of the subscriber to get data for.
+  /// @param aor[out]  - The retrieved data. This is only valid if the return
+  ///                    code is Store::Status::OK. The caller must delete the
+  ///                    AoR.
+  /// @param trail[in] - The SAS trail ID
+  ///
+  /// @return Whether the AoR was successfully written. This can be one of:
+  ///   OK - The AoR was successfully retrieved.
+  ///   ERROR - Something went wrong - there's no point in retrying. The AoR is
+  ///           not valid.
+  ///   NOT_FOUND - We successfully contacted the store but there was no entry
+  ///               for the subscriber. The AoR is not valid.
   Store::Status get_aor(const std::string& aor_id,
                         AoR** aor,
                         SAS::TrailId trail);
-  Store::Status write_aor(const std::string& aor_id,
-                          AoR* aor,
+
+  /// This writes data to memcached (calling into the underlying data store),
+  /// and returns whether the write was successful. This only calls into the
+  /// local store.
+  ///
+  /// @param id[in]    - The ID of the subscriber to update.
+  /// @param aor[in]   - The AoR object to write.
+  /// @param trail[in] - The SAS trail ID.
+  ///
+  /// @return Whether the AoR was successfully written. This can be one of:
+  ///   OK - The AoR was successfully written.
+  ///   ERROR - Something went wrong - there's no point in retrying
+  ///   DATA_CONTENTION - We successfully contacted the store, but there was a
+  ///                     CAS conflict. We can try the write again.
+  Store::Status write_aor(const std::string& id,
+                          AoR& aor,
                           SAS::TrailId trail);
 
+  /// Gets the ID of this S4. This is only used for logging.
+  ///
+  /// @return The ID of this S4
+  inline std::string get_id() { return _id; }
+
+  /// The ID of this S4.
   std::string _id;
+
+  /// The callback URI this S4 puts on Chronos timers. This should be a hostname
+  /// that resolves to all the local S4s in the local site.
+  std::string _chronos_callback_uri;
+
+  /// The interface to Rogers (which owns actually reading and
+  /// writing to Rogers, and coverting between an AoR object and the JSON
+  /// representation of the AoR object.
   AoRStore* _aor_store;
+
+  /// The remote S4s. This is empty if this S4 is a remote S4 already.
   std::vector<S4*> _remote_s4s;
 };
 

--- a/include/s4.h
+++ b/include/s4.h
@@ -20,6 +20,8 @@
 #include <stdlib.h>
 
 #include "sas.h"
+#include "analyticslogger.h"
+#include "associated_uris.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"
 
@@ -38,16 +40,25 @@ public:
 
   HTTPCode handle_get(std::string aor_id,
                       AoR** aor,
+                      uint64_t& version,
                       SAS::TrailId trail);
-  HTTPCode handle_delete(std::string aor_id,
+
+  HTTPCode handle_local_delete(std::string aor_id,
+                               uint64_t cas,
+                               SAS::TrailId trail);
+  HTTPCode handle_remote_delete(std::string aor_id,
                          SAS::TrailId trail);
+
   HTTPCode handle_put(std::string aor_id,
                       AoR* aor,
                       SAS::TrailId id);
+
   HTTPCode handle_patch(std::string aor_id,
-                        PatchObject* patch_object,
+                        PatchObject* po,
+                        AoR** aor,
                         SAS::TrailId trail);
 
+  std::string get_id() { return _id; }
 private:
   void replicate_delete_cross_site(std::string aor_id,
                                    SAS::TrailId trail);
@@ -57,6 +68,13 @@ private:
   void replicate_put_cross_site(std::string aor_id,
                                 AoR* aor,
                                 SAS::TrailId trail);
+
+  Store::Status get_aor(const std::string& aor_id,
+                        AoR** aor,
+                        SAS::TrailId trail);
+  Store::Status write_aor(const std::string& aor_id,
+                          AoR* aor,
+                          SAS::TrailId trail);
 
   std::string _id;
   AoRStore* _aor_store;

--- a/include/s4.h
+++ b/include/s4.h
@@ -27,18 +27,24 @@
 class S4
 {
 public:
-  /// S4 constructor
+  /// S4 constructor - used for local S4s
   ///
   /// @param id[in]           - Site name of the S4. This is only used in logs.
   /// @param callback_uri[in] - Hostname that resolves to the S4s in the local
   ///                           site. Used as the Chronos callback URI.
   /// @param aor_store[in]    - Pointer to the underlying data store interface
-  /// @param remote_s4s[in]   - Pointers to all the remote S4s. If a remote S4
-  ///                           is created then this is an empty vector.
+  /// @param remote_s4s[in]   - Pointers to all the remote S4s.
   S4(std::string id,
      std::string callback_url,
      AoRStore* aor_store,
      std::vector<S4*> remote_s4s);
+
+  /// S4 constructor - used for remote S4s
+  ///
+  /// @param id[in]           - Site name of the S4. This is only used in logs.
+  /// @param aor_store[in]    - Pointer to the underlying data store interface
+  S4(std::string id,
+     AoRStore* aor_store);
 
   /// Destructor.
   ///
@@ -176,9 +182,15 @@ private:
   ///                    public identity.
   /// @param po[in]    - The patch object to patch and update the subscriber
   ///                    with.
+  /// @param aor[in]   - The AoR object to update the subscriber with. This is
+  ///                    only used if the PATCH fails with PRECONDITION_FAILED,
+  ///                    which is returned if the subscriber doesn't exist on
+  ///                    the remote site. In this case we send a PUT with the
+  ///                    aor.
   /// @param trail[in] - The SAS trail ID
   void replicate_patch_cross_site(const std::string& aor_id,
                                   const PatchObject& po,
+                                  const AoR& aor,
                                   SAS::TrailId trail);
 
   /// This replicates a PUT request from a client to the remote S4s. This

--- a/include/s4.h
+++ b/include/s4.h
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 
 #include "sas.h"
-#include "analyticslogger.h"
 #include "associated_uris.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"

--- a/include/s4.h
+++ b/include/s4.h
@@ -36,17 +36,17 @@ public:
   /// Destructor.
   virtual ~S4();
 
-  HTTPCode handle_get(std::string aor_id,
-                      AoR** aor,
-                      SAS::TrailId trail);
-  HTTPCode handle_delete(std::string aor_id,
-                         SAS::TrailId trail);
-  HTTPCode handle_put(std::string aor_id,
-                      AoR* aor,
-                      SAS::TrailId id);
-  HTTPCode handle_patch(std::string aor_id,
-                        PatchObject* patch_object,
-                        SAS::TrailId trail);
+  virtual HTTPCode handle_get(std::string aor_id,
+                              AoR** aor,
+                              SAS::TrailId trail);
+  virtual HTTPCode handle_delete(std::string aor_id,
+                                 SAS::TrailId trail);
+  virtual HTTPCode handle_put(std::string aor_id,
+                              AoR* aor,
+                              SAS::TrailId id);
+  virtual HTTPCode handle_patch(std::string aor_id,
+                                PatchObject* patch_object,
+                                SAS::TrailId trail);
 
 private:
   void replicate_delete_cross_site(std::string aor_id,

--- a/include/s4.h
+++ b/include/s4.h
@@ -295,10 +295,7 @@ private:
 
   /// The ID of this S4.
   std::string _id;
-<<<<<<< HEAD
   ChronosTimerRequestSender* _chronos_timer_request_sender;
-||||||| merged common ancestors
-=======
 
   /// The callback URI this S4 puts on Chronos timers. This should be a hostname
   /// that resolves to all the local S4s in the local site.
@@ -307,7 +304,6 @@ private:
   /// The interface to Rogers (which owns actually reading and
   /// writing to Rogers, and coverting between an AoR object and the JSON
   /// representation of the AoR object.
->>>>>>> master
   AoRStore* _aor_store;
 
   /// The remote S4s. This is empty if this S4 is a remote S4 already.

--- a/include/s4.h
+++ b/include/s4.h
@@ -1,0 +1,67 @@
+/**
+ * @file s4.h
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#ifndef S4_H__
+#define S4_H__
+
+#include <string>
+#include <list>
+#include <map>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sas.h"
+#include "analyticslogger.h"
+#include "astaire_aor_store.h"
+#include "httpclient.h"
+
+class S4
+{
+public:
+  /// S4 constructor.
+  ///
+  /// @param aor_store          - Pointer to the underlying data store interface
+  S4(std::string id,
+     AoRStore* aor_store,
+     std::vector<S4*> remote_s4s);
+
+  /// Destructor.
+  virtual ~S4();
+
+  HTTPCode handle_get(std::string aor_id,
+                      AoR** aor,
+                      SAS::TrailId trail);
+  HTTPCode handle_delete(std::string aor_id,
+                         SAS::TrailId trail);
+  HTTPCode handle_put(std::string aor_id,
+                      AoR* aor,
+                      SAS::TrailId id);
+  HTTPCode handle_patch(std::string aor_id,
+                        PatchObject* patch_object,
+                        SAS::TrailId trail);
+
+private:
+  void replicate_delete_cross_site(std::string aor_id,
+                                   SAS::TrailId trail);
+  void replicate_patch_cross_site(std::string aor_id,
+                                  PatchObject* po,
+                                  SAS::TrailId trail);
+  void replicate_put_cross_site(std::string aor_id,
+                                AoR* aor,
+                                SAS::TrailId trail);
+
+  std::string _id;
+  AoRStore* _aor_store;
+  std::vector<S4*> _remote_s4s;
+};
+
+#endif

--- a/include/s4.h
+++ b/include/s4.h
@@ -23,14 +23,70 @@
 #include "associated_uris.h"
 #include "astaire_aor_store.h"
 #include "httpclient.h"
+#include "chronosconnection.h"
 
 class S4
 {
 public:
-  /// S4 constructor.
+  /// @class S4::ChronosTimerRequestSender
   ///
-  /// @param aor_store          - Pointer to the underlying data store interface
+  /// Class responsible for sending any requests to Chronos about
+  /// registration/subscription expiry
+  ///
+  /// @param chronos_conn    The underlying chronos connection
+  class ChronosTimerRequestSender
+  {
+  public:
+    ChronosTimerRequestSender(ChronosConnection* chronos_conn);
+
+    virtual ~ChronosTimerRequestSender();
+
+    /// Create and send any appropriate Chronos requests
+    ///
+    /// @param aor_id       The AoR ID
+    /// @param aor_pair     The AoR pair to send Chronos requests for
+    /// @param now          The current time
+    /// @param trail        SAS trail
+    virtual void send_timers(const std::string& aor_id,
+                             AoR* aor,
+                             int now,
+                             SAS::TrailId trail);
+
+    /// S4 is the only class that can use ChronosTimerRequestSender
+    friend class S4;
+
+  private:
+    ChronosConnection* _chronos_conn;
+
+    /// Build the tag info map from an AoR
+    virtual void build_tag_info(AoR* aor,
+                                std::map<std::string, uint32_t>& tag_map);
+
+    /// Create the Chronos Timer request
+    ///
+    /// @param aor_id       The AoR ID
+    /// @param timer_id     The Timer ID
+    /// @param expiry       Timer length
+    /// @param tags         Any tags to add to the Chronos timer
+    /// @param trail        SAS trail
+    virtual void set_timer(const std::string& aor_id,
+                           std::string& timer_id,
+                           int expiry,
+                           std::map<std::string, uint32_t> tags,
+                           SAS::TrailId trail);
+  };
+
+  /**
+   * @brief S4 constructor
+   *
+   * @param id
+   * @param chronos_connection - Chronos connection used to set timers for
+   *                             expiring registrations and subscriptions.
+   * @param aor_store         - Pointer to the underlying data store interface
+   * @param remote_s4s        - vector of pointer to remote S4 stores
+   */
   S4(std::string id,
+     ChronosConnection* chronos_connection,
      AoRStore* aor_store,
      std::vector<S4*> remote_s4s);
 
@@ -74,6 +130,7 @@ private:
                           SAS::TrailId trail);
 
   std::string _id;
+  ChronosTimerRequestSender* _chronos_timer_request_sender;
   AoRStore* _aor_store;
   std::vector<S4*> _remote_s4s;
 };

--- a/include/s4sasevent.h
+++ b/include/s4sasevent.h
@@ -1,0 +1,37 @@
+/**
+ * @file s4sasevent.h S4-specific SAS event IDs
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef S4SASEVENT_H__
+#define S4SASEVENT_H__
+
+#include "sasevent.h"
+
+// @todo Define S$_BASE in cpp-common and renumber the events in the resource
+// bundle.
+const int S4_BASE = 0x810000;
+
+namespace SASEvent
+{
+  //----------------------------------------------------------------------------
+  // S4 events.
+  //----------------------------------------------------------------------------
+  const int REGSTORE_GET_FOUND = S4_BASE + 0x000070;
+  const int REGSTORE_GET_NEW = S4_BASE + 0x000071;
+  const int REGSTORE_GET_FAILURE = S4_BASE + 0x000072;
+  const int REGSTORE_SET_START = S4_BASE + 0x000073;
+  const int REGSTORE_SET_SUCCESS = S4_BASE + 0x000074;
+  const int REGSTORE_SET_FAILURE = S4_BASE + 0x000075;
+  const int REGSTORE_DESERIALIZATION_FAILED = S4_BASE + 0x000076;
+
+} //namespace SASEvent
+
+#endif
+

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -1,0 +1,546 @@
+/**
+ * @file aor.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <limits.h>
+
+#include "log.h"
+#include "aor.h"
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+/// Default constructor.
+AoR::AoR(std::string sip_uri) :
+  _notify_cseq(1),
+  _timer_id(""),
+  _scscf_uri(""),
+  _bindings(),
+  _subscriptions(),
+  _associated_uris(),
+  _cas(0),
+  _uri(sip_uri)
+{
+}
+
+
+/// Destructor.
+AoR::~AoR()
+{
+  clear(true);
+}
+
+
+/// Copy constructor.
+AoR::AoR(const AoR& other)
+{
+  common_constructor(other);
+}
+
+// Make sure assignment is deep!
+AoR& AoR::operator= (AoR const& other)
+{
+  if (this != &other)
+  {
+    clear(true);
+    common_constructor(other);
+  }
+
+  return *this;
+}
+
+void AoR::common_constructor(const AoR& other)
+{
+  for (Bindings::const_iterator i = other._bindings.begin();
+       i != other._bindings.end();
+       ++i)
+  {
+    Binding* bb = new Binding(*i->second);
+    _bindings.insert(std::make_pair(i->first, bb));
+  }
+
+  for (Subscriptions::const_iterator i = other._subscriptions.begin();
+       i != other._subscriptions.end();
+       ++i)
+  {
+    Subscription* ss = new Subscription(*i->second);
+    _subscriptions.insert(std::make_pair(i->first, ss));
+  }
+
+  _associated_uris = AssociatedURIs(other._associated_uris);
+  _notify_cseq = other._notify_cseq;
+  _timer_id = other._timer_id;
+  _cas = other._cas;
+  _uri = other._uri;
+  _scscf_uri = other._scscf_uri;
+}
+
+/// Clear all the bindings and subscriptions from this object.
+void AoR::clear(bool clear_emergency_bindings)
+{
+  for (Bindings::iterator i = _bindings.begin();
+       i != _bindings.end();
+       )
+  {
+    if ((clear_emergency_bindings) || (!i->second->_emergency_registration))
+    {
+      delete i->second;
+      _bindings.erase(i++);
+    }
+    else
+    {
+      ++i;
+    }
+  }
+
+  if (clear_emergency_bindings)
+  {
+    _bindings.clear();
+  }
+
+  for (Subscriptions::iterator i = _subscriptions.begin();
+       i != _subscriptions.end();
+       ++i)
+  {
+    delete i->second;
+  }
+
+  _subscriptions.clear();
+  _associated_uris.clear_uris();
+}
+
+
+/// Retrieve a binding by binding identifier, creating an empty one if
+/// necessary.  The created binding is completely empty, even the Contact URI
+/// field.
+Binding* AoR::get_binding(const std::string& binding_id)
+{
+  Binding* b;
+  AoR::Bindings::const_iterator i = _bindings.find(binding_id);
+  if (i != _bindings.end())
+  {
+    b = i->second;
+  }
+  else
+  {
+    // No existing binding with this id, so create a new one.
+    b = new Binding(_uri);
+    b->_expires = 0;
+    _bindings.insert(std::make_pair(binding_id, b));
+  }
+  return b;
+}
+
+
+/// Removes any binding that had the given ID.  If there is no such binding,
+/// does nothing.
+void AoR::remove_binding(const std::string& binding_id)
+{
+  AoR::Bindings::iterator i = _bindings.find(binding_id);
+  if (i != _bindings.end())
+  {
+    delete i->second;
+    _bindings.erase(i);
+  }
+}
+
+/// Retrieve a subscription by To tag, creating an empty subscription if
+/// necessary.
+Subscription* AoR::get_subscription(const std::string& to_tag)
+{
+  Subscription* s;
+  AoR::Subscriptions::const_iterator i = _subscriptions.find(to_tag);
+  if (i != _subscriptions.end())
+  {
+    s = i->second;
+  }
+  else
+  {
+    // No existing subscription with this tag, so create a new one.
+    s = new Subscription;
+    _subscriptions.insert(std::make_pair(to_tag, s));
+  }
+  return s;
+}
+
+
+/// Removes the subscription with the specified tag.  If there is no such
+/// subscription, does nothing.
+void AoR::remove_subscription(const std::string& to_tag)
+{
+  AoR::Subscriptions::iterator i = _subscriptions.find(to_tag);
+  if (i != _subscriptions.end())
+  {
+    delete i->second;
+    _subscriptions.erase(i);
+  }
+}
+
+/// Remove all the bindings from an AOR object
+void AoR::clear_bindings()
+{
+  for (Bindings::const_iterator i = _bindings.begin();
+       i != _bindings.end();
+       ++i)
+  {
+    delete i->second;
+  }
+
+  // Clear the bindings map.
+  _bindings.clear();
+}
+
+
+void Binding::
+  to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_URI); writer.String(_uri.c_str());
+    writer.String(JSON_CID); writer.String(_cid.c_str());
+    writer.String(JSON_CSEQ); writer.Int(_cseq);
+    writer.String(JSON_EXPIRES); writer.Int(_expires);
+    writer.String(JSON_PRIORITY); writer.Int(_priority);
+
+    writer.String(JSON_PARAMS);
+    writer.StartObject();
+    {
+      for (std::map<std::string, std::string>::const_iterator p = _params.begin();
+           p != _params.end();
+           ++p)
+      {
+        writer.String(p->first.c_str()); writer.String(p->second.c_str());
+      }
+    }
+    writer.EndObject();
+
+    writer.String(JSON_PATH_HEADERS);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator p = _path_headers.begin();
+           p != _path_headers.end();
+           ++p)
+      {
+        writer.String(p->c_str());
+      }
+    }
+    writer.EndArray();
+
+    // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
+    writer.String(JSON_PATHS);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator p = _path_uris.begin();
+           p != _path_uris.end();
+           ++p)
+      {
+        writer.String(p->c_str());
+      }
+    }
+    writer.EndArray();
+
+    writer.String(JSON_PRIVATE_ID); writer.String(_private_id.c_str());
+    writer.String(JSON_EMERGENCY_REG); writer.Bool(_emergency_registration);
+  }
+  writer.EndObject();
+}
+
+void Binding::from_json(const rapidjson::Value& b_obj)
+{
+
+  JSON_GET_STRING_MEMBER(b_obj, JSON_URI, _uri);
+  JSON_GET_STRING_MEMBER(b_obj, JSON_CID, _cid);
+  JSON_GET_INT_MEMBER(b_obj, JSON_CSEQ, _cseq);
+  JSON_GET_INT_MEMBER(b_obj, JSON_EXPIRES, _expires);
+  JSON_GET_INT_MEMBER(b_obj, JSON_PRIORITY, _priority);
+
+  JSON_ASSERT_CONTAINS(b_obj, JSON_PARAMS);
+  JSON_ASSERT_OBJECT(b_obj[JSON_PARAMS]);
+  const rapidjson::Value& params_obj = b_obj[JSON_PARAMS];
+
+  for (rapidjson::Value::ConstMemberIterator params_it = params_obj.MemberBegin();
+       params_it != params_obj.MemberEnd();
+       ++params_it)
+  {
+    JSON_ASSERT_STRING(params_it->value);
+    _params[params_it->name.GetString()] = params_it->value.GetString();
+  }
+
+  if (b_obj.HasMember(JSON_PATH_HEADERS))
+  {
+    JSON_ASSERT_ARRAY(b_obj[JSON_PATH_HEADERS]);
+    const rapidjson::Value& path_headers_arr = b_obj[JSON_PATH_HEADERS];
+
+    for (rapidjson::Value::ConstValueIterator path_headers_it = path_headers_arr.Begin();
+         path_headers_it != path_headers_arr.End();
+         ++path_headers_it)
+    {
+      JSON_ASSERT_STRING(*path_headers_it);
+      _path_headers.push_back(path_headers_it->GetString());
+    }
+  }
+
+  // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
+  if (b_obj.HasMember(JSON_PATHS))
+  {
+    JSON_ASSERT_ARRAY(b_obj[JSON_PATHS]);
+    const rapidjson::Value& path_uris_arr = b_obj[JSON_PATHS];
+
+    for (rapidjson::Value::ConstValueIterator path_uris_it = path_uris_arr.Begin();
+         path_uris_it != path_uris_arr.End();
+         ++path_uris_it)
+    {
+      JSON_ASSERT_STRING(*path_uris_it);
+      _path_uris.push_back(path_uris_it->GetString());
+    }
+  }
+
+  JSON_GET_STRING_MEMBER(b_obj, JSON_PRIVATE_ID, _private_id);
+  JSON_GET_BOOL_MEMBER(b_obj, JSON_EMERGENCY_REG, _emergency_registration);
+}
+
+void Subscription::
+  to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_REQ_URI); writer.String(_req_uri.c_str());
+    writer.String(JSON_FROM_URI); writer.String(_from_uri.c_str());
+    writer.String(JSON_FROM_TAG); writer.String(_from_tag.c_str());
+    writer.String(JSON_TO_URI); writer.String(_to_uri.c_str());
+    writer.String(JSON_TO_TAG); writer.String(_to_tag.c_str());
+    writer.String(JSON_CID); writer.String(_cid.c_str());
+
+    writer.String(JSON_ROUTES);
+    writer.StartArray();
+    {
+      for (std::list<std::string>::const_iterator r = _route_uris.begin();
+           r != _route_uris.end();
+           ++r)
+      {
+        writer.String(r->c_str());
+      }
+    }
+    writer.EndArray();
+
+    writer.String(JSON_EXPIRES); writer.Int(_expires);
+  }
+  writer.EndObject();
+}
+
+void Subscription::from_json(const rapidjson::Value& s_obj)
+{
+  JSON_GET_STRING_MEMBER(s_obj, JSON_REQ_URI, _req_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_FROM_URI, _from_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_FROM_TAG, _from_tag);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_TO_URI, _to_uri);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_TO_TAG, _to_tag);
+  JSON_GET_STRING_MEMBER(s_obj, JSON_CID, _cid);
+
+  JSON_ASSERT_CONTAINS(s_obj, JSON_ROUTES);
+  JSON_ASSERT_ARRAY(s_obj[JSON_ROUTES]);
+  const rapidjson::Value& routes_arr = s_obj[JSON_ROUTES];
+
+  for (rapidjson::Value::ConstValueIterator routes_it = routes_arr.Begin();
+       routes_it != routes_arr.End();
+       ++routes_it)
+  {
+    JSON_ASSERT_STRING(*routes_it);
+    _route_uris.push_back(routes_it->GetString());
+  }
+
+  JSON_GET_INT_MEMBER(s_obj, JSON_EXPIRES, _expires);
+}
+
+// Utility function to return the expiry time of the binding or subscription due
+// to expire next. If the function finds no expiry times in the bindings or
+// subscriptions it returns 0. This function should never be called on an empty AoR,
+// so a 0 is indicative of something wrong with the _expires values of AoR members.
+int AoR::get_next_expires()
+{
+  // Set a temp int to INT_MAX to compare expiry times to.
+  int _next_expires = INT_MAX;
+
+  for (AoR::Bindings::const_iterator b = _bindings.begin();
+       b != _bindings.end();
+       ++b)
+  {
+    if (b->second->_expires < _next_expires)
+    {
+      _next_expires = b->second->_expires;
+    }
+  }
+  for (AoR::Subscriptions::const_iterator s = _subscriptions.begin();
+       s != _subscriptions.end();
+       ++s)
+  {
+    if (s->second->_expires < _next_expires)
+    {
+      _next_expires = s->second->_expires;
+    }
+  }
+
+  // If nothing has altered the _next_expires, the AoR is empty and invalid.
+  // Return 0 to indicate there is nothing to expire.
+  if (_next_expires == INT_MAX)
+  {
+    return 0;
+  }
+  // Otherwise we return the value found.
+  return _next_expires;
+}
+
+void AoR::copy_aor(AoR* source_aor)
+{
+  for (Bindings::const_iterator i = source_aor->bindings().begin();
+       i != source_aor->bindings().end();
+       ++i)
+  {
+    Binding* src = i->second;
+    Binding* dst = get_binding(i->first);
+    *dst = *src;
+  }
+
+  for (Subscriptions::const_iterator i = source_aor->subscriptions().begin();
+       i != source_aor->subscriptions().end();
+       ++i)
+  {
+    Subscription* src = i->second;
+    Subscription* dst = get_subscription(i->first);
+    *dst = *src;
+  }
+
+  _associated_uris = AssociatedURIs(source_aor->_associated_uris);
+  _notify_cseq = source_aor->_notify_cseq;
+  _timer_id = source_aor->_timer_id;
+  _uri = source_aor->_uri;
+  _scscf_uri = source_aor->_scscf_uri;
+}
+
+AoR::Bindings AoRPair::get_updated_bindings()
+{
+  AoR::Bindings updated_bindings;
+
+  // Iterate over the bindings in the current AoR. Figure out if the bindings
+  // have been created or updated.
+  for (std::pair<std::string, Binding*> current_aor_binding :
+         _current_aor->bindings())
+  {
+    std::string b_id = current_aor_binding.first;
+    Binding* binding = current_aor_binding.second;
+
+    // Find any binding match in the original AoR
+    AoR::Bindings::const_iterator orig_aor_binding_match =
+      _orig_aor->bindings().find(b_id);
+
+    // If the binding is only in the current AoR, it has been created
+    if (orig_aor_binding_match == _orig_aor->bindings().end())
+    {
+      TRC_DEBUG("Binding %s has been created", current_aor_binding.first.c_str());
+      updated_bindings.insert(std::make_pair(b_id, binding));
+    }
+    else
+    {
+      // The binding is in both AoRs. Check if the expiry time has changed at all
+      if (orig_aor_binding_match->second->_expires != binding->_expires)
+      {
+        TRC_DEBUG("Binding %s expiry has been changed", b_id.c_str());
+        updated_bindings.insert(std::make_pair(b_id, binding));
+      }
+      else
+      {
+        TRC_DEBUG("Binding %s is unchanged", b_id.c_str());
+      }
+    }
+  }
+  return updated_bindings;
+}
+
+AoR::Subscriptions AoRPair::get_updated_subscriptions()
+{
+  AoR::Subscriptions updated_subscriptions;
+
+  // Iterate over the subscriptions in the current AoR. Figure out if the
+  // subscriptions have been created or updated.
+  for (std::pair<std::string, Subscription*> current_aor_subscription :
+         _current_aor->subscriptions())
+  {
+    std::string s_id = current_aor_subscription.first;
+    Subscription* subscription = current_aor_subscription.second;
+
+    // Find any subscriptions match in the original AoR
+    AoR::Subscriptions::const_iterator orig_aor_subscription_match =
+      _orig_aor->subscriptions().find(s_id);
+
+    // If the subscription is only in the current AoR, it has been created
+    if (orig_aor_subscription_match == _orig_aor->subscriptions().end())
+    {
+      TRC_DEBUG("Subscription %s has been created", current_aor_subscription.first.c_str());
+      updated_subscriptions.insert(std::make_pair(s_id, subscription));
+    }
+    else
+    {
+      // The subscription is in both AoRs. Check if the expiry time has changed at all
+      if (orig_aor_subscription_match->second->_expires != subscription->_expires)
+      {
+        TRC_DEBUG("Subscription %s expiry has been changed", s_id.c_str());
+        updated_subscriptions.insert(std::make_pair(s_id, subscription));
+      }
+      else
+      {
+        TRC_DEBUG("Subscription %s is unchanged", s_id.c_str());
+      }
+    }
+  }
+
+  return updated_subscriptions;
+}
+
+AoR::Bindings AoRPair::get_removed_bindings()
+{
+  AoR::Bindings removed_bindings;
+
+  // Iterate over original bindings and record those not in current AoR
+  for (std::pair<std::string, Binding*> orig_aor_binding :
+         _orig_aor->bindings())
+  {
+    if (_current_aor->bindings().find(orig_aor_binding.first) ==
+        _current_aor->bindings().end())
+    {
+      // Binding is gone (which may mean deregistration or expiry)
+      TRC_DEBUG("Binding %s has been removed", orig_aor_binding.first.c_str());
+      removed_bindings.insert(std::make_pair(orig_aor_binding.first,
+                                             orig_aor_binding.second));
+    }
+  }
+
+  return removed_bindings;
+}
+
+AoR::Subscriptions AoRPair::get_removed_subscriptions()
+{
+  AoR::Subscriptions removed_subscriptions;
+
+  // Iterate over original subscriptions and record those not in current AoR
+  for (std::pair<std::string, Subscription*> orig_aor_subscription :
+         _orig_aor->subscriptions())
+  {
+    // Is this subscription present in the new AoR?
+    if (_current_aor->subscriptions().find(orig_aor_subscription.first) ==
+        _current_aor->subscriptions().end())
+    {
+      // Subscription is gone
+      TRC_DEBUG("Subscription %s is no longer present",
+                    orig_aor_subscription.first.c_str());
+      removed_subscriptions.insert(std::make_pair(orig_aor_subscription.first,
+                                                  orig_aor_subscription.second));
+    }
+  }
+  return removed_subscriptions;
+}

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -197,6 +197,15 @@ void AoR::clear_bindings()
 }
 
 
+Binding::Binding(std::string address_of_record) :
+  _address_of_record(address_of_record),
+  _cseq(0),
+  _expires(0),
+  _priority(0),
+  _emergency_registration(false)
+{}
+
+
 void Binding::
   to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const
 {

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -232,19 +232,6 @@ void Binding::
     }
     writer.EndArray();
 
-    // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
-    writer.String(JSON_PATHS);
-    writer.StartArray();
-    {
-      for (std::list<std::string>::const_iterator p = _path_uris.begin();
-           p != _path_uris.end();
-           ++p)
-      {
-        writer.String(p->c_str());
-      }
-    }
-    writer.EndArray();
-
     writer.String(JSON_PRIVATE_ID); writer.String(_private_id.c_str());
     writer.String(JSON_EMERGENCY_REG); writer.Bool(_emergency_registration);
   }
@@ -283,21 +270,6 @@ void Binding::from_json(const rapidjson::Value& b_obj)
     {
       JSON_ASSERT_STRING(*path_headers_it);
       _path_headers.push_back(path_headers_it->GetString());
-    }
-  }
-
-  // SDM-REFACTOR-TODO: We don't need this upgrade code anymore. Delete it.
-  if (b_obj.HasMember(JSON_PATHS))
-  {
-    JSON_ASSERT_ARRAY(b_obj[JSON_PATHS]);
-    const rapidjson::Value& path_uris_arr = b_obj[JSON_PATHS];
-
-    for (rapidjson::Value::ConstValueIterator path_uris_it = path_uris_arr.Begin();
-         path_uris_it != path_uris_arr.End();
-         ++path_uris_it)
-    {
-      JSON_ASSERT_STRING(*path_uris_it);
-      _path_uris.push_back(path_uris_it->GetString());
     }
   }
 
@@ -420,10 +392,10 @@ int AoR::get_next_expires()
   return _next_expires;
 }
 
-void AoR::copy_aor(AoR* source_aor)
+void AoR::copy_aor(const AoR& source_aor)
 {
-  for (Bindings::const_iterator i = source_aor->bindings().begin();
-       i != source_aor->bindings().end();
+  for (Bindings::const_iterator i = source_aor.bindings().begin();
+       i != source_aor.bindings().end();
        ++i)
   {
     Binding* src = i->second;
@@ -431,8 +403,8 @@ void AoR::copy_aor(AoR* source_aor)
     *dst = *src;
   }
 
-  for (Subscriptions::const_iterator i = source_aor->subscriptions().begin();
-       i != source_aor->subscriptions().end();
+  for (Subscriptions::const_iterator i = source_aor.subscriptions().begin();
+       i != source_aor.subscriptions().end();
        ++i)
   {
     Subscription* src = i->second;
@@ -440,11 +412,101 @@ void AoR::copy_aor(AoR* source_aor)
     *dst = *src;
   }
 
-  _associated_uris = AssociatedURIs(source_aor->_associated_uris);
-  _notify_cseq = source_aor->_notify_cseq;
-  _timer_id = source_aor->_timer_id;
-  _uri = source_aor->_uri;
-  _scscf_uri = source_aor->_scscf_uri;
+  _associated_uris = AssociatedURIs(source_aor._associated_uris);
+  _notify_cseq = source_aor._notify_cseq;
+  _timer_id = source_aor._timer_id;
+  _uri = source_aor._uri;
+  _scscf_uri = source_aor._scscf_uri;
+}
+
+// Patch the AoR. This does the following:
+//
+// TODO
+void AoR::patch_aor(const PatchObject& po)
+{
+  TRC_DEBUG("Patching the AoR for %s", _uri.c_str());
+
+  for (BindingPair b : po.get_update_bindings())
+  {
+    TRC_DEBUG("Updating the binding %s", b.first.c_str());
+
+    for (BindingPair b2 : _bindings)
+    {
+      if (b.first == b2.first)
+      {
+        _bindings.erase(b2.first);
+        delete b2.second;
+        break;
+      }
+    }
+
+    Binding* copy_b = new Binding(*(b.second));
+    _bindings.insert(std::make_pair(b.first, copy_b));
+  }
+
+  for (std::string b_id : po.get_remove_bindings())
+  {
+    TRC_DEBUG("Removing the binding %s", b_id.c_str());
+
+    for (BindingPair b : _bindings)
+    {
+      if (b_id == b.first)
+      {
+        _bindings.erase(b.first);
+        delete b.second;
+        break;
+      }
+    }
+  }
+
+  for (SubscriptionPair s : po.get_update_subscriptions())
+  {
+    TRC_DEBUG("Updating the subscription %s", s.first.c_str());
+
+    for (SubscriptionPair s2 : _subscriptions)
+    {
+      if (s.first == s2.first)
+      {
+        _subscriptions.erase(s2.first);
+        delete s2.second;
+        break;
+      }
+    }
+
+    Subscription* copy_s = new Subscription(*(s.second));
+    _subscriptions.insert(std::make_pair(s.first, copy_s));
+  }
+
+  for (std::string s_id : po.get_remove_subscriptions())
+  {
+    TRC_DEBUG("Removing the subscription %s", s_id.c_str());
+
+    for (SubscriptionPair s : _subscriptions)
+    {
+      if (s_id == s.first)
+      {
+        _subscriptions.erase(s.first);
+        delete s.second;
+        break;
+      }
+    }
+  }
+
+  if (po.get_associated_uris())
+  {
+    TRC_DEBUG("Updating the Associated URIs");
+    _associated_uris = po.get_associated_uris().get();
+  }
+
+  if (po.get_increment_cseq())
+  {
+    _notify_cseq++;
+  }
+
+  if ((po.get_minimum_cseq() != 0) && (_notify_cseq < po.get_minimum_cseq()))
+  {
+    _notify_cseq = po.get_minimum_cseq();
+  }
 }
 
 Bindings AoRPair::get_updated_bindings()
@@ -565,89 +627,12 @@ Subscriptions AoRPair::get_removed_subscriptions()
   return removed_subscriptions;
 }
 
-void AoR::patch_aor(const PatchObject& po)
-{
-  for (BindingPair b : po.get_update_bindings())
-  {
-    for (BindingPair b2 : _bindings)
-    {
-      if (b.first == b2.first)
-      {
-        _bindings.erase(b2.first);
-        delete b2.second;
-        break;
-      }
-    }
-
-    Binding* copy_b = new Binding(*(b.second));
-    _bindings.insert(std::make_pair(b.first, copy_b));
-  }
-
-  for (std::string b_id : po.get_remove_bindings())
-  {
-    for (BindingPair b : _bindings)
-    {
-      if (b_id == b.first)
-      {
-        _bindings.erase(b.first);
-        delete b.second;
-        break;
-      }
-    }
-  }
-
-  for (SubscriptionPair s : po.get_update_subscriptions())
-  {
-    for (SubscriptionPair s2 : _subscriptions)
-    {
-      if (s.first == s2.first)
-      {
-        _subscriptions.erase(s2.first);
-        delete s2.second;
-        break;
-      }
-    }
-
-    Subscription* copy_s = new Subscription(*(s.second));
-    _subscriptions.insert(std::make_pair(s.first, copy_s));
-  }
-
-  for (std::string s_id : po.get_remove_subscriptions())
-  {
-    for (SubscriptionPair s : _subscriptions)
-    {
-      if (s_id == s.first)
-      {
-        _subscriptions.erase(s.first);
-        delete s.second;
-        break;
-      }
-    }
-  }
-
-  //if (po->_associated_uris != NULL)
-  //{
-  //  delete _associated_uris;
-  //  _associated_uris = po->_associated_uris;
-  //}
-
-  if (po.get_increment_cseq())
-  {
-    _notify_cseq++;
-  }
-
-  if ((po.get_minimum_cseq() != 0) && (_notify_cseq < po.get_minimum_cseq()))
-  {
-    _notify_cseq = po.get_minimum_cseq();
-  }
-}
-
-// TODO assouris?
 PatchObject::PatchObject() :
   _update_bindings({}),
   _remove_bindings({}),
   _update_subscriptions({}),
   _remove_subscriptions({}),
+  _associated_uris(boost::optional<AssociatedURIs>{}),
   _minimum_cseq(0),
   _increment_cseq(false)
 {}
@@ -700,6 +685,11 @@ void PatchObject::common_constructor(const PatchObject& other)
     _remove_subscriptions.push_back(subscription);
   }
 
+  if (other.get_associated_uris())
+  {
+    _associated_uris = other.get_associated_uris().get();
+  }
+
   _minimum_cseq = other.get_minimum_cseq();
   _increment_cseq = other.get_increment_cseq();
 }
@@ -715,4 +705,36 @@ void PatchObject::clear()
   {
     delete s.second; s.second = NULL;
   }
+}
+
+/// Convert an AoR to a PatchObject.
+///
+/// @param aor - AoR to convert to a PatchObject
+/// @param po  - PatchObject to be populated with the AoR info
+void convert_aor_to_patch(const AoR& aor, PatchObject& po)
+{
+  Bindings patch_bindings;
+
+  for (BindingPair binding : aor.bindings())
+  {
+    patch_bindings.insert(
+                 std::make_pair(binding.first, new Binding(*(binding.second))));
+  }
+
+  Subscriptions patch_subscriptions;
+
+  for (SubscriptionPair subscription : aor.subscriptions())
+  {
+    patch_subscriptions.insert(
+                      std::make_pair(subscription.first,
+                                     new Subscription(*(subscription.second))));
+  }
+
+  AssociatedURIs associated_uris = aor._associated_uris;
+  int minimum = aor._notify_cseq;
+
+  po.set_update_bindings(patch_bindings);
+  po.set_update_subscriptions(patch_subscriptions);
+  po.set_associated_uris(associated_uris);
+  po.set_minimum_cseq(minimum);
 }

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -122,7 +122,7 @@ void AoR::clear(bool clear_emergency_bindings)
 Binding* AoR::get_binding(const std::string& binding_id)
 {
   Binding* b;
-  AoR::Bindings::const_iterator i = _bindings.find(binding_id);
+  Bindings::const_iterator i = _bindings.find(binding_id);
   if (i != _bindings.end())
   {
     b = i->second;
@@ -142,7 +142,7 @@ Binding* AoR::get_binding(const std::string& binding_id)
 /// does nothing.
 void AoR::remove_binding(const std::string& binding_id)
 {
-  AoR::Bindings::iterator i = _bindings.find(binding_id);
+  Bindings::iterator i = _bindings.find(binding_id);
   if (i != _bindings.end())
   {
     delete i->second;
@@ -155,7 +155,7 @@ void AoR::remove_binding(const std::string& binding_id)
 Subscription* AoR::get_subscription(const std::string& to_tag)
 {
   Subscription* s;
-  AoR::Subscriptions::const_iterator i = _subscriptions.find(to_tag);
+  Subscriptions::const_iterator i = _subscriptions.find(to_tag);
   if (i != _subscriptions.end())
   {
     s = i->second;
@@ -174,7 +174,7 @@ Subscription* AoR::get_subscription(const std::string& to_tag)
 /// subscription, does nothing.
 void AoR::remove_subscription(const std::string& to_tag)
 {
-  AoR::Subscriptions::iterator i = _subscriptions.find(to_tag);
+  Subscriptions::iterator i = _subscriptions.find(to_tag);
   if (i != _subscriptions.end())
   {
     delete i->second;
@@ -364,7 +364,7 @@ void AoR::get_next_and_last_expires(int& next_expires, int& last_expires)
   next_expires = INT_MAX;
   last_expires = 0;
 
-  for (std::pair<std::string, Binding*> b : _bindings)
+  for (BindingPair b : _bindings)
   {
     if (b.second->_expires < next_expires)
     {
@@ -377,7 +377,7 @@ void AoR::get_next_and_last_expires(int& next_expires, int& last_expires)
     }
   }
 
-  for (std::pair<std::string, Subscription*> s : _subscriptions)
+  for (SubscriptionPair s : _subscriptions)
   {
     if (s.second->_expires < next_expires)
     {
@@ -400,7 +400,7 @@ int AoR::get_next_expires()
   // Set a temp int to INT_MAX to compare expiry times to.
   int _next_expires = INT_MAX;
 
-  for (AoR::Bindings::const_iterator b = _bindings.begin();
+  for (Bindings::const_iterator b = _bindings.begin();
        b != _bindings.end();
        ++b)
   {
@@ -409,7 +409,7 @@ int AoR::get_next_expires()
       _next_expires = b->second->_expires;
     }
   }
-  for (AoR::Subscriptions::const_iterator s = _subscriptions.begin();
+  for (Subscriptions::const_iterator s = _subscriptions.begin();
        s != _subscriptions.end();
        ++s)
   {
@@ -456,20 +456,19 @@ void AoR::copy_aor(AoR* source_aor)
   _scscf_uri = source_aor->_scscf_uri;
 }
 
-AoR::Bindings AoRPair::get_updated_bindings()
+Bindings AoRPair::get_updated_bindings()
 {
-  AoR::Bindings updated_bindings;
+  Bindings updated_bindings;
 
   // Iterate over the bindings in the current AoR. Figure out if the bindings
   // have been created or updated.
-  for (std::pair<std::string, Binding*> current_aor_binding :
-         _current_aor->bindings())
+  for (BindingPair current_aor_binding : _current_aor->bindings())
   {
     std::string b_id = current_aor_binding.first;
     Binding* binding = current_aor_binding.second;
 
     // Find any binding match in the original AoR
-    AoR::Bindings::const_iterator orig_aor_binding_match =
+    Bindings::const_iterator orig_aor_binding_match =
       _orig_aor->bindings().find(b_id);
 
     // If the binding is only in the current AoR, it has been created
@@ -495,20 +494,19 @@ AoR::Bindings AoRPair::get_updated_bindings()
   return updated_bindings;
 }
 
-AoR::Subscriptions AoRPair::get_updated_subscriptions()
+Subscriptions AoRPair::get_updated_subscriptions()
 {
-  AoR::Subscriptions updated_subscriptions;
+  Subscriptions updated_subscriptions;
 
   // Iterate over the subscriptions in the current AoR. Figure out if the
   // subscriptions have been created or updated.
-  for (std::pair<std::string, Subscription*> current_aor_subscription :
-         _current_aor->subscriptions())
+  for (SubscriptionPair current_aor_subscription : _current_aor->subscriptions())
   {
     std::string s_id = current_aor_subscription.first;
     Subscription* subscription = current_aor_subscription.second;
 
     // Find any subscriptions match in the original AoR
-    AoR::Subscriptions::const_iterator orig_aor_subscription_match =
+    Subscriptions::const_iterator orig_aor_subscription_match =
       _orig_aor->subscriptions().find(s_id);
 
     // If the subscription is only in the current AoR, it has been created
@@ -535,13 +533,12 @@ AoR::Subscriptions AoRPair::get_updated_subscriptions()
   return updated_subscriptions;
 }
 
-AoR::Bindings AoRPair::get_removed_bindings()
+Bindings AoRPair::get_removed_bindings()
 {
-  AoR::Bindings removed_bindings;
+  Bindings removed_bindings;
 
   // Iterate over original bindings and record those not in current AoR
-  for (std::pair<std::string, Binding*> orig_aor_binding :
-         _orig_aor->bindings())
+  for (BindingPair orig_aor_binding : _orig_aor->bindings())
   {
     if (_current_aor->bindings().find(orig_aor_binding.first) ==
         _current_aor->bindings().end())
@@ -556,13 +553,12 @@ AoR::Bindings AoRPair::get_removed_bindings()
   return removed_bindings;
 }
 
-AoR::Subscriptions AoRPair::get_removed_subscriptions()
+Subscriptions AoRPair::get_removed_subscriptions()
 {
-  AoR::Subscriptions removed_subscriptions;
+  Subscriptions removed_subscriptions;
 
   // Iterate over original subscriptions and record those not in current AoR
-  for (std::pair<std::string, Subscription*> orig_aor_subscription :
-         _orig_aor->subscriptions())
+  for (SubscriptionPair orig_aor_subscription :_orig_aor->subscriptions())
   {
     // Is this subscription present in the new AoR?
     if (_current_aor->subscriptions().find(orig_aor_subscription.first) ==
@@ -580,9 +576,9 @@ AoR::Subscriptions AoRPair::get_removed_subscriptions()
 
 void AoR::patch_aor(PatchObject* po)
 {
-  for (std::pair<std::string, Binding*> b : po->update_bindings())
+  for (BindingPair b : po->update_bindings())
   {
-    for (std::pair<std::string, Binding*> b2 : _bindings)
+    for (BindingPair b2 : _bindings)
     {
       if (b.first == b2.first)
       {
@@ -598,7 +594,7 @@ void AoR::patch_aor(PatchObject* po)
 
   for (std::string b_id : po->remove_bindings())
   {
-    for (std::pair<std::string, Binding*> b : _bindings)
+    for (BindingPair b : _bindings)
     {
       if (b_id == b.first)
       {
@@ -609,9 +605,9 @@ void AoR::patch_aor(PatchObject* po)
     }
   }
 
-  for (std::pair<std::string, Subscription*> s : po->update_subscriptions())
+  for (SubscriptionPair s : po->update_subscriptions())
   {
-    for (std::pair<std::string, Subscription*> s2 : _subscriptions)
+    for (SubscriptionPair s2 : _subscriptions)
     {
       if (s.first == s2.first)
       {
@@ -627,7 +623,7 @@ void AoR::patch_aor(PatchObject* po)
 
   for (std::string s_id : po->remove_subscriptions())
   {
-    for (std::pair<std::string, Subscription*> s : _subscriptions)
+    for (SubscriptionPair s : _subscriptions)
     {
       if (s_id == s.first)
       {
@@ -667,12 +663,12 @@ PatchObject::PatchObject() :
 
 PatchObject::~PatchObject()
 {
-  for (std::pair<std::string, Binding*> b : _update_bindings)
+  for (BindingPair b : _update_bindings)
   {
     delete b.second; b.second = NULL;
   }
 
-  for (std::pair<std::string, Subscription*> s : _update_subscriptions)
+  for (SubscriptionPair s : _update_subscriptions)
   {
     delete s.second; s.second = NULL;
   }

--- a/src/associated_uris.cpp
+++ b/src/associated_uris.cpp
@@ -1,0 +1,240 @@
+/**
+ * @file associated_uris.cpp Implementation of the AssociatedURIs class.
+ *
+ * Copyright (C) Metaswitch Networks
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "associated_uris.h"
+#include "log.h"
+
+#include <algorithm>
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+// Gets the default URI. We return the first unbarred URI. If there is no
+// unbarred URI, we don't return anything unless it is an emergency in which
+// case we return the first URI.
+bool AssociatedURIs::get_default_impu(std::string& uri,
+                                      bool emergency)
+{
+  std::vector<std::string> unbarred_uris = this->get_unbarred_uris();
+  if (!unbarred_uris.empty())
+  {
+    uri = unbarred_uris.front();
+    return true;
+  }
+
+  if ((emergency) &&
+      (!_associated_uris.empty()))
+  {
+    uri = _associated_uris.front();
+    return true;
+  }
+
+  return false;
+}
+
+// Checks if the URI is in the list of associated URIs.
+bool AssociatedURIs::contains_uri(std::string uri)
+{
+  return (std::find(_associated_uris.begin(), _associated_uris.end(), uri) !=
+          _associated_uris.end());
+}
+
+// Adds a URI and its barring state to the list of associated URIs.
+void AssociatedURIs::add_uri(std::string uri,
+                             bool barred)
+{
+  _associated_uris.push_back(uri);
+  add_barring_status(uri, barred);
+}
+
+// Adds the barring state of a URI. This map includes URIs that aren't in the
+// associated URI list (e.g. it includes non-distinct IMPUs)
+void AssociatedURIs::add_barring_status(std::string uri,
+                                        bool barred)
+{
+  _barred_map[uri] = barred;
+}
+
+// Removes all URIs.
+void AssociatedURIs::clear_uris()
+{
+  _associated_uris.clear();
+  _barred_map.clear();
+  _distinct_to_wildcard.clear();
+}
+
+// Returns if the specified URI is barred.
+bool AssociatedURIs::is_impu_barred(std::string uri)
+{
+  // Sometimes we don't have the barring status of the specific URI as it's
+  // actually an URI that matches a wildcard - get the wildcard URI before
+  // we check the barring status. In the case where a non-distinct IMPU
+  // has had its barring indication set specifically in the IMS subscription
+  // we got from the HSS then it was directly added to the _barred_map (and
+  // not added to the _distinct_to_wildcard map).
+  std::string uri_to_check = uri;
+  if (_distinct_to_wildcard.find(uri) != _distinct_to_wildcard.end())
+  {
+    uri_to_check = _distinct_to_wildcard[uri];
+  }
+
+  if (_barred_map.find(uri_to_check) != _barred_map.end())
+  {
+    return _barred_map[uri_to_check];
+  }
+  else
+  {
+    // We shouldn't ever end up here - return false (we do hit this in UTs
+    // though as we don't always use valid data).
+    TRC_DEBUG("No barring information available for %s", uri.c_str());
+    return false;
+  }
+}
+
+// Returns all unbarred associated URIs.
+std::vector<std::string> AssociatedURIs::get_unbarred_uris()
+{
+  std::vector<std::string> unbarred_uris;
+
+  for (std::string uri : _associated_uris)
+  {
+    if (!_barred_map[uri])
+    {
+      unbarred_uris.push_back(uri);
+    }
+  }
+
+  return unbarred_uris;
+}
+
+// Returns all barred associated URIs.
+std::vector<std::string> AssociatedURIs::get_barred_uris()
+{
+  std::vector<std::string> barred_uris;
+
+  for (std::string uri : _associated_uris)
+  {
+    if (_barred_map[uri])
+    {
+      barred_uris.push_back(uri);
+    }
+  }
+
+  return barred_uris;
+}
+
+// Returns all associated URIs.
+std::vector<std::string> AssociatedURIs::get_all_uris()
+{
+  return _associated_uris;
+}
+
+// Returns the wildcard mapping
+std::map<std::string, std::string> AssociatedURIs::get_wildcard_mapping()
+{
+  return _distinct_to_wildcard;
+}
+
+// Sets up the link between a distinct IMPU and its wildcard.
+void AssociatedURIs::add_wildcard_mapping(std::string wildcard,
+                                          std::string distinct)
+{
+  _distinct_to_wildcard.insert(std::make_pair(distinct, wildcard));
+}
+
+// Expected format of json:
+// {"uris": [{"uri": "sip:uri", "barring": false},.......],
+//  "wildcard-mapping": {"distinct": ".....", "wildcard": "......"}}
+void AssociatedURIs::to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer)
+{
+  writer.StartObject();
+  {
+    writer.String(JSON_URIS);
+    writer.StartArray();
+    for (std::vector<std::string>::iterator uris_it = _associated_uris.begin();
+         uris_it != _associated_uris.end();
+         uris_it++)
+    {
+      bool uri_barred = is_impu_barred(*uris_it);
+      writer.StartObject();
+      {
+        writer.String(JSON_URI); writer.String((*uris_it).c_str());
+        writer.String(JSON_BARRING); writer.Bool(uri_barred);
+      }
+      writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.String(JSON_WILDCARD_MAPPING);
+    writer.StartObject();
+    {
+      if (get_wildcard_mapping().size() != 0)
+      {
+        writer.String(JSON_DISTINCT);
+        writer.String(get_wildcard_mapping().begin()->first.c_str());
+        writer.String(JSON_WILDCARD);
+        writer.String(get_wildcard_mapping().begin()->second.c_str());
+      }
+    }
+    writer.EndObject();
+  }
+  writer.EndObject();
+}
+
+void AssociatedURIs::from_json(const rapidjson::Value& au_obj)
+{
+  JSON_ASSERT_CONTAINS(au_obj, JSON_URIS);
+  JSON_ASSERT_ARRAY(au_obj[JSON_URIS]);
+  const rapidjson::Value& associated_uris_arr = au_obj[JSON_URIS];
+
+  clear_uris();
+
+  for (rapidjson::Value::ConstValueIterator associated_uris_it = associated_uris_arr.Begin();
+       associated_uris_it != associated_uris_arr.End();
+       ++associated_uris_it)
+  {
+    std::string uri;
+    bool barring;
+    JSON_GET_STRING_MEMBER(*associated_uris_it, JSON_URI, uri);
+    JSON_GET_BOOL_MEMBER(*associated_uris_it, JSON_BARRING, barring);
+    TRC_DEBUG("From JSON - Adding URI: %s, barring: %d", uri.c_str(), barring);
+    add_uri(uri, barring);
+  }
+
+  JSON_ASSERT_CONTAINS(au_obj, JSON_WILDCARD_MAPPING);
+  JSON_ASSERT_OBJECT(au_obj[JSON_WILDCARD_MAPPING]);
+  const rapidjson::Value& wildcard_obj = au_obj[JSON_WILDCARD_MAPPING];
+
+  if (wildcard_obj.HasMember(JSON_DISTINCT))
+  {
+    std::string distinct;
+    std::string wildcard;
+    JSON_GET_STRING_MEMBER(wildcard_obj, JSON_DISTINCT, distinct)
+    JSON_GET_STRING_MEMBER(wildcard_obj, JSON_WILDCARD, wildcard)
+
+    add_wildcard_mapping(distinct, wildcard);
+  }
+}
+
+bool AssociatedURIs::operator==(AssociatedURIs associated_uris_other)
+{
+  // Only comparing associated URIs and barring, not wildcard mappings
+  if (_associated_uris != associated_uris_other.get_all_uris() ||
+      get_barred_uris() != associated_uris_other.get_barred_uris())
+  {
+    return false;
+  }
+  return true;
+}
+
+bool AssociatedURIs::operator!=(AssociatedURIs associated_uris_other)
+{
+  return !(operator==(associated_uris_other));
+}

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -144,6 +144,7 @@ Store::Status AstaireAoRStore::Connector::set_aor_data(
   event.add_var_param(aor_id);
   SAS::report_event(event);
 
+  printf("\nsetting\n");
   Store::Status status = _data_store->set_data("reg",
                                                aor_id,
                                                data,

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -266,7 +266,7 @@ std::string AstaireAoRStore::JsonSerializerDeserializer::serialize_aor(AoR* aor_
     writer.String(JSON_BINDINGS);
     writer.StartObject();
     {
-      for (AoR::Bindings::const_iterator it = aor_data->bindings().begin();
+      for (Bindings::const_iterator it = aor_data->bindings().begin();
            it != aor_data->bindings().end();
            ++it)
       {
@@ -282,7 +282,7 @@ std::string AstaireAoRStore::JsonSerializerDeserializer::serialize_aor(AoR* aor_
     writer.String(JSON_SUBSCRIPTIONS);
     writer.StartObject();
     {
-      for (AoR::Subscriptions::const_iterator it = aor_data->subscriptions().begin();
+      for (Subscriptions::const_iterator it = aor_data->subscriptions().begin();
            it != aor_data->subscriptions().end();
            ++it)
       {

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -1,0 +1,301 @@
+/**
+ * @file astaire_aor_store.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#include "log.h"
+#include "s4sasevent.h"
+#include "astaire_aor_store.h"
+#include "json_parse_utils.h"
+#include "rapidjson/error/en.h"
+
+
+AstaireAoRStore::AstaireAoRStore(Store* store) : AoRStore()
+{
+  JsonSerializerDeserializer* serializer_deserializer = new JsonSerializerDeserializer();
+  _connector = new Connector(store, serializer_deserializer); // Takes ownership of serializer_deserializer
+}
+
+AstaireAoRStore::~AstaireAoRStore()
+{
+  // Ownership of serializer_deserializer passed to _connector
+  delete _connector; _connector = NULL;
+}
+
+/// AstaireAoRStore methods
+
+/// Calls through into the connector get and set commands
+AoR* AstaireAoRStore::get_aor_data(const std::string& aor_id,
+                                   SAS::TrailId trail)
+{
+  return _connector->get_aor_data(aor_id, trail);
+}
+
+
+Store::Status AstaireAoRStore::set_aor_data(const std::string& aor_id,
+                                            AoR* aor,
+                                            int expiry,
+                                            SAS::TrailId trail)
+{
+  return _connector->set_aor_data(aor_id,
+                                  aor,
+                                  expiry,
+                                  trail);
+}
+
+/// AstaireAoRStore::Connector Methods
+
+AstaireAoRStore::Connector::Connector(Store* data_store,
+                            JsonSerializerDeserializer*& serializer_deserializer) :
+  _data_store(data_store),
+  _serializer_deserializer(serializer_deserializer)
+{
+  // We have taken ownership of the serializer_deserializer.
+  serializer_deserializer = NULL;
+}
+
+AstaireAoRStore::Connector::~Connector()
+{
+  delete _serializer_deserializer; _serializer_deserializer = NULL;
+}
+
+/// Retrieve the registration data for a given SIP Address of Record, creating
+/// an empty record if no data exists for the AoR.
+///
+/// @param aor_id       The SIP Address of Record for the registration
+AoR* AstaireAoRStore::Connector::get_aor_data(
+                                             const std::string& aor_id,
+                                             SAS::TrailId trail)
+{
+  TRC_DEBUG("Get AoR data for %s", aor_id.c_str());
+  AoR* aor_data = NULL;
+
+  std::string data;
+  uint64_t cas;
+  Store::Status status = _data_store->get_data("reg", aor_id, data, cas, trail);
+
+  if (status == Store::Status::OK)
+  {
+    // Retrieved the data, so deserialize it.
+    TRC_DEBUG("Data store returned a record, CAS = %ld", cas);
+    aor_data = _serializer_deserializer->deserialize_aor(aor_id, data);
+
+    if (aor_data != NULL)
+    {
+      aor_data->_cas = cas;
+
+      SAS::Event event(trail, SASEvent::REGSTORE_GET_FOUND, 0);
+      event.add_var_param(aor_id);
+      SAS::report_event(event);
+    }
+    else
+    {
+      // Could not deserialize the record. Treat it as not found.
+      TRC_INFO("Failed to deserialize record");
+      SAS::Event event(trail, SASEvent::REGSTORE_DESERIALIZATION_FAILED, 0);
+      event.add_var_param(aor_id);
+      event.add_var_param(data);
+      SAS::report_event(event);
+    }
+  }
+  else if (status == Store::Status::NOT_FOUND)
+  {
+    // Data store didn't find the record, so create a new blank record.
+    aor_data = new AoR(aor_id);
+
+    SAS::Event event(trail, SASEvent::REGSTORE_GET_NEW, 0);
+    event.add_var_param(aor_id);
+    SAS::report_event(event);
+
+    TRC_DEBUG("Data store returned not found, so create new record, CAS = %ld",
+              aor_data->_cas);
+  }
+  else
+  {
+    SAS::Event event(trail, SASEvent::REGSTORE_GET_FAILURE, 0);
+    event.add_var_param(aor_id);
+    SAS::report_event(event);
+  }
+
+  return aor_data;
+}
+
+Store::Status AstaireAoRStore::Connector::set_aor_data(
+                                            const std::string& aor_id,
+                                            AoR* aor_data,
+                                            int expiry,
+                                            SAS::TrailId trail)
+{
+  std::string data = _serializer_deserializer->serialize_aor(aor_data);
+
+  SAS::Event event(trail, SASEvent::REGSTORE_SET_START, 0);
+  event.add_var_param(aor_id);
+  SAS::report_event(event);
+
+  Store::Status status = _data_store->set_data("reg",
+                                               aor_id,
+                                               data,
+                                               aor_data->_cas,
+                                               expiry,
+                                               trail);
+
+  TRC_DEBUG("Data store set_data returned %d", status);
+
+  if (status == Store::Status::OK)
+  {
+    SAS::Event event2(trail, SASEvent::REGSTORE_SET_SUCCESS, 0);
+    event2.add_var_param(aor_id);
+    SAS::report_event(event2);
+  }
+  else
+  {
+    SAS::Event event2(trail, SASEvent::REGSTORE_SET_FAILURE, 0);
+    event2.add_var_param(aor_id);
+    SAS::report_event(event2);
+  }
+
+  return status;
+}
+
+
+//
+// (De)serializer for the JSON SubscriberDataManager format.
+//
+
+AoR* AstaireAoRStore::JsonSerializerDeserializer::
+  deserialize_aor(const std::string& aor_id, const std::string& s)
+{
+  TRC_DEBUG("Deserialize JSON document: %s", s.c_str());
+
+  rapidjson::Document doc;
+  doc.Parse<0>(s.c_str());
+
+  if (doc.HasParseError())
+  {
+    TRC_DEBUG("Failed to parse document: %s\nError: %s",
+              s.c_str(),
+              rapidjson::GetParseError_En(doc.GetParseError()));
+    return NULL;
+  }
+
+  AoR* aor = new AoR(aor_id);
+
+  try
+  {
+    JSON_ASSERT_OBJECT(doc);
+    JSON_ASSERT_CONTAINS(doc, JSON_BINDINGS);
+    JSON_ASSERT_OBJECT(doc[JSON_BINDINGS]);
+    const rapidjson::Value& bindings_obj = doc[JSON_BINDINGS];
+
+    for (rapidjson::Value::ConstMemberIterator bindings_it = bindings_obj.MemberBegin();
+         bindings_it != bindings_obj.MemberEnd();
+         ++bindings_it)
+    {
+      TRC_DEBUG("  Binding: %s", bindings_it->name.GetString());
+      Binding* b = aor->get_binding(bindings_it->name.GetString());
+
+      JSON_ASSERT_OBJECT(bindings_it->value);
+      const rapidjson::Value& b_obj = bindings_it->value;
+
+      b->from_json(b_obj);
+    }
+
+    JSON_ASSERT_CONTAINS(doc, JSON_SUBSCRIPTIONS);
+    JSON_ASSERT_OBJECT(doc[JSON_SUBSCRIPTIONS]);
+    const rapidjson::Value& subscriptions_obj = doc[JSON_SUBSCRIPTIONS];
+
+    for (rapidjson::Value::ConstMemberIterator subscriptions_it = subscriptions_obj.MemberBegin();
+         subscriptions_it != subscriptions_obj.MemberEnd();
+         ++subscriptions_it)
+    {
+      TRC_DEBUG("  Subscription: %s", subscriptions_it->name.GetString());
+      Subscription* s = aor->get_subscription(subscriptions_it->name.GetString());
+
+      JSON_ASSERT_OBJECT(subscriptions_it->value);
+      const rapidjson::Value& s_obj = subscriptions_it->value;
+
+      s->from_json(s_obj);
+    }
+
+    if (doc.HasMember(JSON_ASSOCIATED_URIS))
+    {
+      JSON_ASSERT_OBJECT(doc[JSON_ASSOCIATED_URIS]);
+      const rapidjson::Value& au_obj = doc[JSON_ASSOCIATED_URIS];
+      aor->_associated_uris.from_json(au_obj);
+    }
+
+    JSON_GET_INT_MEMBER(doc, JSON_NOTIFY_CSEQ, aor->_notify_cseq);
+
+    JSON_SAFE_GET_STRING_MEMBER(doc, JSON_TIMER_ID, aor->_timer_id);
+    JSON_SAFE_GET_STRING_MEMBER(doc, JSON_SCSCF_URI, aor->_scscf_uri);
+  }
+  catch(JsonFormatError err)
+  {
+    TRC_INFO("Failed to deserialize JSON document (hit error at %s:%d)",
+             err._file, err._line);
+    delete aor; aor = NULL;
+  }
+
+  return aor;
+}
+
+
+std::string AstaireAoRStore::JsonSerializerDeserializer::serialize_aor(AoR* aor_data)
+{
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+
+  writer.StartObject();
+  {
+    //
+    // Bindings
+    //
+    writer.String(JSON_BINDINGS);
+    writer.StartObject();
+    {
+      for (AoR::Bindings::const_iterator it = aor_data->bindings().begin();
+           it != aor_data->bindings().end();
+           ++it)
+      {
+        writer.String(it->first.c_str());
+        it->second->to_json(writer);
+      }
+    }
+    writer.EndObject();
+
+    //
+    // Subscriptions.
+    //
+    writer.String(JSON_SUBSCRIPTIONS);
+    writer.StartObject();
+    {
+      for (AoR::Subscriptions::const_iterator it = aor_data->subscriptions().begin();
+           it != aor_data->subscriptions().end();
+           ++it)
+      {
+        writer.String(it->first.c_str());
+        it->second->to_json(writer);
+      }
+    }
+    writer.EndObject();
+
+    // Associated URIs
+    writer.String(JSON_ASSOCIATED_URIS);
+    aor_data->_associated_uris.to_json(writer);
+
+    // Notify Cseq flag
+    writer.String(JSON_NOTIFY_CSEQ); writer.Int(aor_data->_notify_cseq);
+    writer.String(JSON_TIMER_ID); writer.String(aor_data->_timer_id.c_str());
+    writer.String(JSON_SCSCF_URI); writer.String(aor_data->_scscf_uri.c_str());
+  }
+  writer.EndObject();
+
+  return sb.GetString();
+}

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -79,7 +79,12 @@ AoR* AstaireAoRStore::Connector::get_aor_data(
 
   std::string data;
   uint64_t cas;
-  Store::Status status = _data_store->get_data("reg", aor_id, data, cas, trail);
+  Store::Status status = _data_store->get_data("reg",
+                                               aor_id,
+                                               data,
+                                               cas,
+                                               trail,
+                                               Store::Format::JSON);
 
   if (status == Store::Status::OK)
   {
@@ -144,7 +149,8 @@ Store::Status AstaireAoRStore::Connector::set_aor_data(
                                                data,
                                                aor_data->_cas,
                                                expiry,
-                                               trail);
+                                               trail,
+                                               Store::Format::JSON);
 
   TRC_DEBUG("Data store set_data returned %d", status);
 

--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -144,7 +144,6 @@ Store::Status AstaireAoRStore::Connector::set_aor_data(
   event.add_var_param(aor_id);
   SAS::report_event(event);
 
-  printf("\nsetting\n");
   Store::Status status = _data_store->set_data("reg",
                                                aor_id,
                                                data,

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -491,8 +491,9 @@ Store::Status S4::write_aor(const std::string& id,
   int now = time(NULL);
 
   // Send any Chronos timer requests
-  if (_chronos_timer_request_sender->_chronos_conn && !_remote_s4s.empty())
+  if (_chronos_timer_request_sender->_chronos_conn)
   {
+   TRC_DEBUG("IN HER");
     _chronos_timer_request_sender->send_timers(id, &aor, now, trail);
   }
 
@@ -600,19 +601,6 @@ void S4::ChronosTimerRequestSender::set_timer(
   else
   {
     temp_timer_id = timer_id;
-    status = _chronos_conn->send_put(temp_timer_id,
-                                     expiry,
-                                     callback_uri,
-                                     opaque,
-                                     trail,
-                                     tags);
-  }
-
-  // Update the timer id. If the update to Chronos failed, that's OK,
-  // don't reject the request or update the stored timer id.
-  if (status == HTTP_OK)
-  {
-    timer_id = temp_timer_id;
     status = _chronos_conn->send_put(temp_timer_id,
                                      expiry,
                                      callback_uri,

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -442,13 +442,14 @@ Store::Status S4::write_aor(const std::string& aor_id,
 {
   int next_expires;
   int last_expires;
+  int now = time(NULL);
   aor->get_next_and_last_expires(next_expires, last_expires);
 
-  TRC_DEBUG("Expires are %d, %d", next_expires, last_expires);
+  TRC_DEBUG("Expires are %d, %d: Now is %d", next_expires, last_expires, now);
   // SDM-REFACTOR-TODO: Set Chronos timer.
 
   return _aor_store->set_aor_data(aor_id,
                                   aor,
-                                  last_expires,
+                                  last_expires + 10,
                                   trail);
 }

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -1,0 +1,336 @@
+/**
+ * @file s4.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+// Common STL includes.
+#include <cassert>
+#include <vector>
+#include <map>
+#include <set>
+#include <list>
+#include <queue>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <iomanip>
+#include <algorithm>
+#include <time.h>
+
+#include "log.h"
+#include "utils.h"
+#include "s4.h"
+#include "astaire_aor_store.h"
+
+// SDM-REFACTOR-TODO:
+// Commonise logic in the handles? Or at least make more similar.
+// TRC statements
+// SAS logging (poss already covered by memcached logs)
+// Lifetimes of AoRs?
+// Implement PATCH
+// Implement PATCH/PUT conversion, and protect against loops
+// Implement max_expiry
+// Full UT
+
+S4::S4(std::string id,
+       AoRStore* aor_store,
+       std::vector<S4*> remote_s4s) :
+  _id(id),
+  _aor_store(aor_store),
+  _remote_s4s(remote_s4s)
+{
+}
+
+S4::~S4()
+{
+}
+
+HTTPCode S4::handle_get(std::string aor_id,
+                        AoR** aor,
+                        SAS::TrailId trail)
+{
+  HTTPCode rc;
+  bool retry_get = true;
+
+  while (retry_get)
+  {
+    *aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL || *aor == NULL)
+    {
+      // Failed to get data for the AoR because there is no connection
+      // to the store. This will already have been SAS logged by the AoR store.
+      TRC_DEBUG("Store error for %s. Failed to get AoR for %s from store",
+                _id.c_str(),
+                aor_id.c_str());
+      rc = HTTP_SERVER_ERROR;
+      retry_get = false;
+    }
+    else if ((*aor)->bindings().empty())
+    {
+      // If we don't have any bindings, try the remote stores.
+      TRC_DEBUG("AoR is empty for %s in %s",
+                aor_id.c_str(),
+                _id.c_str());
+      rc = HTTP_NOT_FOUND;
+      retry_get = false;
+
+      for (S4* remote_s4 : _remote_s4s)
+      {
+        AoR* remote_aor = NULL;
+        HTTPCode remote_rc = remote_s4->handle_get(aor_id, &remote_aor, trail);
+
+        if (remote_rc == HTTP_OK)
+        {
+          // The remote store has an entry for this AoR and it has bindings -
+          // copy the information across.
+          (*aor)->copy_aor(remote_aor);
+          Store::Status store_rc = _aor_store->set_aor_data(aor_id, *aor, (*aor)->get_expiry(), trail);
+
+          if (store_rc == Store::Status::ERROR)
+          {
+            // We haven't been able to write the data back to memcached.
+            rc = HTTP_SERVER_ERROR;
+          }
+          else if (store_rc == Store::Status::OK)
+          {
+            rc = HTTP_OK;
+          }
+          else if (store_rc == Store::Status::DATA_CONTENTION)
+          {
+            retry_get = true;
+          }
+
+          break;
+        }
+        else if (remote_rc == HTTP_NOT_FOUND)
+        {
+          // We created an AoR but it's empty. Free it off.
+          delete remote_aor; remote_aor = NULL;
+        }
+      }
+    }
+    else
+    {
+      retry_get = false;
+      rc = HTTP_OK;
+    }
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_delete(std::string aor_id, SAS::TrailId trail)
+{
+  Store::Status store_rc = Store::Status::DATA_CONTENTION;
+
+  while (store_rc == Store::Status::DATA_CONTENTION)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL)
+    {
+      store_rc = Store::Status::ERROR;
+    }
+    else if (aor->bindings().empty())
+    {
+      store_rc = Store::Status::OK;
+    }
+    else
+    {
+      // Clear the AoR.
+      aor->clear(true);
+
+      // Write the empty AoR back to the store.
+      store_rc = _aor_store->set_aor_data(aor_id, aor, aor->get_expiry(), trail);
+    }
+  }
+
+  HTTPCode rc;
+
+  if (store_rc == Store::Status::OK)
+  {
+    // Subscriber has been deleted from the local site, so send the DELETE
+    // out to the remote sites. The response to the SM is always going to be
+    // OK independently of whether any remote DELETEs are successful.
+    replicate_delete_cross_site(aor_id, trail);
+    rc = HTTP_OK;
+  }
+  else
+  {
+    // Failed to delete data - we don't try and delete the subscriber from
+    // any remote sites.
+    TRC_DEBUG("Failed to delete subscriber %s from %s",
+              aor_id.c_str(),
+              _id.c_str());
+    rc = HTTP_SERVER_ERROR;
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_put(std::string aor_id,
+                        AoR* new_aor,
+                        SAS::TrailId trail)
+{
+  HTTPCode rc = HTTP_OK;
+
+  while (true)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* current_aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (current_aor == NULL)
+    {
+      rc = HTTP_SERVER_ERROR;
+      break;
+    }
+    else if (!current_aor->bindings().empty())
+    {
+      // We already have data for this AoR, so we shouldn't have had a PUT for it.
+      rc = HTTP_UNPROCESSABLE_ENTITY;
+      delete current_aor; current_aor = NULL;
+      break;
+    }
+    else
+    {
+      // Update the AoR with the requested changes.
+      current_aor->copy_aor(new_aor);
+      Store::Status store_rc = _aor_store->set_aor_data(aor_id,
+                                                        current_aor,
+                                                        current_aor->get_expiry(),
+                                                        trail);
+
+      if (store_rc == Store::Status::OK)
+      {
+        replicate_put_cross_site(aor_id, new_aor, trail);
+        rc = HTTP_OK;
+        break;
+      }
+      else if (store_rc == Store::Status::ERROR)
+      {
+        // Failed to add data - we don't try and add the subscriber to
+        // any remote sites.
+        TRC_DEBUG("Failed to add subscriber %s to %s",
+                  aor_id.c_str(),
+                  _id.c_str());
+        rc = HTTP_SERVER_ERROR;
+        break;
+      }
+    }
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_patch(std::string aor_id,
+                          PatchObject* po,
+                          SAS::TrailId trail)
+{
+  HTTPCode rc = HTTP_OK;
+
+  while (true)
+  {
+    // Get the AoR from the data store - this only looks in the local store.
+    AoR* aor = _aor_store->get_aor_data(aor_id, trail);
+
+    if (aor == NULL)
+    {
+      rc = HTTP_SERVER_ERROR;
+      break;
+    }
+    else if (aor->bindings().empty())
+    {
+      // We don't have data for this AoR, so we shouldn't have had a PATCH for it.
+      rc = HTTP_NOT_FOUND;
+      delete aor; aor = NULL;
+      break;
+    }
+    else
+    {
+      // Update the AoR with the requested changes.
+      aor->patch_aor(po);
+      Store::Status store_rc = _aor_store->set_aor_data(aor_id,
+                                                        aor,
+                                                        aor->get_expiry(),
+                                                        trail);
+
+      if (store_rc == Store::Status::OK)
+      {
+        replicate_patch_cross_site(aor_id, po, trail);
+        rc = HTTP_OK;
+        break;
+      }
+      else if (store_rc == Store::Status::ERROR)
+      {
+        // Failed to updateadd data - we don't try and update the subscriber in
+        // any remote sites.
+        TRC_DEBUG("Failed to update subscriber %s to %s",
+                  aor_id.c_str(),
+                  _id.c_str());
+        rc = HTTP_SERVER_ERROR;
+        break;
+      }
+    }
+  }
+
+  return rc;
+}
+
+void S4::replicate_delete_cross_site(std::string aor_id,
+                                     SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    remote_s4->handle_delete(aor_id, trail);
+  }
+}
+
+void S4::replicate_put_cross_site(std::string aor_id,
+                                  AoR* aor,
+                                  SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    HTTPCode rc = remote_s4->handle_put(aor_id, aor, trail);
+
+    if (rc == HTTP_UNPROCESSABLE_ENTITY)
+    {
+      // We've tried to do a PUT to a remote site that already has data. We need
+      // to send a PATCH instead.
+      TRC_DEBUG("Need to convert PUT to PATCH for %s", _id.c_str());
+      PatchObject* po = new PatchObject();
+      aor->convert_aor_to_patch(po);
+      remote_s4->handle_patch(aor_id, po, trail);
+    }
+  }
+}
+
+void S4::replicate_patch_cross_site(std::string aor_id,
+                                    PatchObject* po,
+                                    SAS::TrailId trail)
+{
+  for (S4* remote_s4 : _remote_s4s)
+  {
+    HTTPCode rc = remote_s4->handle_patch(aor_id, po, trail);
+
+    if (rc == HTTP_UNPROCESSABLE_ENTITY)
+    {
+      // We've tried to do a PATCH to a remote site that doesn't have any data.
+      // We need to send a PUT.
+      TRC_DEBUG("Need to convert PATCH to PUT for %s", _id.c_str());
+      AoR* aor = new AoR(aor_id);
+      aor->convert_patch_to_aor(po);
+      remote_s4->handle_put(aor_id, aor, trail);
+    }
+  }
+}

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -488,18 +488,14 @@ Store::Status S4::write_aor(const std::string& id,
                             AoR& aor,
                             SAS::TrailId trail)
 {
-  int next_expires;
-  int last_expires;
   int now = time(NULL);
-  aor->get_next_and_last_expires(next_expires, last_expires);
-
-  TRC_DEBUG("Expires are %d, %d: Now is %d", next_expires, last_expires, now);
 
   // Send any Chronos timer requests
   if (_chronos_timer_request_sender->_chronos_conn && !_remote_s4s.empty())
   {
-    _chronos_timer_request_sender->send_timers(aor_id, aor, now, trail);
+    _chronos_timer_request_sender->send_timers(id, &aor, now, trail);
   }
+
   Store::Status rc = _aor_store->set_aor_data(id,
                                               &aor,
                                               aor.get_last_expires() + 10,
@@ -514,6 +510,8 @@ Store::Status S4::write_aor(const std::string& id,
     TRC_DEBUG("Failed to write AoR for %s to %s",
               id.c_str(), _id.c_str());
   }
+
+  return rc;
 }
 
 S4::ChronosTimerRequestSender::

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -29,8 +29,6 @@
 #include "utils.h"
 #include "s4.h"
 #include "astaire_aor_store.h"
-#include "sproutsasevent.h"
-#include "constants.h"
 
 // SDM-REFACTOR-TODO:
 // 1. Commonise logic in the handles? Or at least make more similar.

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -29,6 +29,7 @@
 #include "utils.h"
 #include "s4.h"
 #include "astaire_aor_store.h"
+#include "chronosconnection.h"
 
 // SDM-REFACTOR-TODO:
 // 1. Commonise logic in the handles? Or at least make more similar.
@@ -41,16 +42,19 @@
 // 8. Full UT
 
 S4::S4(std::string id,
+       ChronosConnection* chronos_connection,
        AoRStore* aor_store,
        std::vector<S4*> remote_s4s) :
   _id(id),
   _aor_store(aor_store),
   _remote_s4s(remote_s4s)
 {
+  _chronos_timer_request_sender = new ChronosTimerRequestSender(chronos_connection);
 }
 
 S4::~S4()
 {
+  delete _chronos_timer_request_sender;
 }
 
 HTTPCode S4::handle_get(std::string aor_id,
@@ -446,10 +450,133 @@ Store::Status S4::write_aor(const std::string& aor_id,
   aor->get_next_and_last_expires(next_expires, last_expires);
 
   TRC_DEBUG("Expires are %d, %d: Now is %d", next_expires, last_expires, now);
-  // SDM-REFACTOR-TODO: Set Chronos timer.
+
+  // Send any Chronos timer requests
+  if (_chronos_timer_request_sender->_chronos_conn && !_remote_s4s.empty())
+  {
+    _chronos_timer_request_sender->send_timers(aor_id, aor, now, trail);
+  }
 
   return _aor_store->set_aor_data(aor_id,
                                   aor,
                                   last_expires + 10,
                                   trail);
 }
+
+S4::ChronosTimerRequestSender::
+     ChronosTimerRequestSender(ChronosConnection* chronos_conn) :
+  _chronos_conn(chronos_conn)
+{
+}
+
+S4::ChronosTimerRequestSender::~ChronosTimerRequestSender()
+{
+}
+
+
+void S4::ChronosTimerRequestSender::build_tag_info (
+                                       AoR* aor,
+                                       std::map<std::string, uint32_t>& tag_map)
+{
+  // Each timer is built to represent a single registration i.e. an AoR.
+  tag_map["REG"] = 1;
+  tag_map["BIND"] = aor->get_bindings_count();
+  tag_map["SUB"] = aor->get_subscriptions_count();
+}
+
+
+void S4::ChronosTimerRequestSender::send_timers(const std::string& aor_id,
+                                                AoR* aor,
+                                                int now,
+                                                SAS::TrailId trail)
+{
+  std::map<std::string, uint32_t> tags;
+  std::string& timer_id = aor->_timer_id;
+
+  // An AoR with no bindings is invalid, and the timer should be deleted.
+  // We do this before getting next_expires to save on processing.
+  if (aor->get_bindings_count() == 0)
+  {
+    if (timer_id != "")
+    {
+      _chronos_conn->send_delete(timer_id, trail);
+    }
+    return;
+  }
+
+  build_tag_info(aor, tags);
+  int next_expires = aor->get_next_expires();
+
+  if (next_expires == 0)
+  {
+    // This should never happen, as an empty AoR should never reach get_next_expires
+    TRC_DEBUG("get_next_expires returned 0. The expiry of AoR members is corrupt, or an empty (invalid) AoR was passed in.");
+  }
+
+    // Set the expiry time to be relative to now.
+    int expiry = (next_expires > now) ? (next_expires - now) : (now);
+
+    set_timer(aor_id,
+              timer_id,
+              expiry,
+              tags,
+              trail);
+}
+
+void S4::ChronosTimerRequestSender::set_timer(
+                                          const std::string& aor_id,
+                                          std::string& timer_id,
+                                          int expiry,
+                                          std::map<std::string, uint32_t> tags,
+                                          SAS::TrailId trail)
+{
+  std::string temp_timer_id = "";
+  HTTPCode status;
+  std::string opaque = "{\"aor_id\": \"" + aor_id + "\"}";
+  std::string callback_uri = "/timers";
+
+  // If a timer has been previously set for this binding, send a PUT.
+  // Otherwise sent a POST.
+  if (timer_id == "")
+  {
+    printf("\n\nempty post\n\n");
+    status = _chronos_conn->send_post(temp_timer_id,
+                                      expiry,
+                                      callback_uri,
+                                      opaque,
+                                      trail,
+                                      tags);
+  }
+  else
+  {
+    printf("ID %s", timer_id.c_str());
+    temp_timer_id = timer_id;
+    status = _chronos_conn->send_put(temp_timer_id,
+                                     expiry,
+                                     callback_uri,
+                                     opaque,
+                                     trail,
+                                     tags);
+  }
+
+  // Update the timer id. If the update to Chronos failed, that's OK,
+  // don't reject the request or update the stored timer id.
+  if (status == HTTP_OK)
+  {
+    timer_id = temp_timer_id;
+    status = _chronos_conn->send_put(temp_timer_id,
+                                     expiry,
+                                     callback_uri,
+                                     opaque,
+                                     trail,
+                                     tags);
+  }
+
+  // Update the timer id. If the update to Chronos failed, that's OK,
+  // don't reject the request or update the stored timer id.
+  if (status == HTTP_OK)
+  {
+    timer_id = temp_timer_id;
+  }
+}
+

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -31,9 +31,6 @@
 #include "astaire_aor_store.h"
 #include "chronosconnection.h"
 
-// SDM-REFACTOR-TODO:
-// 8. Full UT
-
 S4::S4(std::string id,
        ChronosConnection* chronos_connection,
        std::string callback_uri,
@@ -495,6 +492,14 @@ Store::Status S4::write_aor(const std::string& id,
                             AoR& aor,
                             SAS::TrailId trail)
 {
+  // If the AoR has no bindings then it should be deleted. Clear up any
+  // subscriptions.
+  if (aor.bindings().empty() && !aor.subscriptions().empty())
+  {
+    TRC_DEBUG("Cleaning up AoR");
+    aor.clear(true);
+  }
+
   int now = time(NULL);
 
   // Send any Chronos timer requests
@@ -572,7 +577,7 @@ void S4::ChronosTimerRequestSender::send_timers(const std::string& aor_id,
     TRC_DEBUG("get_next_expires returned 0. The expiry of AoR members "
               "is corrupt, or an empty (invalid) AoR was passed in.");
 
-    // LCOV_EXCL_END
+    // LCOV_EXCL_STOP
   }
 
   // Set the expiry time to be relative to now.

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -368,7 +368,10 @@ HTTPCode S4::handle_patch(const std::string& id,
         // Subscriber has been updated on the local site, so send the PATCHs
         // out to the remote sites. The response to the SM is always going to be
         // OK independently of whether any remote PATCHs are successful.
-        replicate_patch_cross_site(id, po, **aor, trail);
+        PatchObject remote_po = PatchObject(po);
+        remote_po.set_increment_cseq(false);
+        remote_po.set_minimum_cseq((*aor)->_notify_cseq);
+        replicate_patch_cross_site(id, remote_po, **aor, trail);
       }
       else if (store_rc == Store::Status::DATA_CONTENTION)
       {

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -456,6 +456,7 @@ Store::Status S4::get_aor(const std::string& id,
                           AoR** aor,
                           SAS::TrailId trail)
 {
+  printf("\ngetting\n");
   Store::Status rc;
 
   *aor = _aor_store->get_aor_data(id, trail);
@@ -493,6 +494,7 @@ Store::Status S4::write_aor(const std::string& id,
   // Send any Chronos timer requests
   if (_chronos_timer_request_sender->_chronos_conn && !_remote_s4s.empty())
   {
+    printf("\nsending\n");
     _chronos_timer_request_sender->send_timers(id, &aor, now, trail);
   }
 
@@ -600,7 +602,7 @@ void S4::ChronosTimerRequestSender::set_timer(
   }
   else
   {
-    printf("ID %s", timer_id.c_str());
+    printf("put ID %s", timer_id.c_str());
     temp_timer_id = timer_id;
     status = _chronos_conn->send_put(temp_timer_id,
                                      expiry,
@@ -610,6 +612,7 @@ void S4::ChronosTimerRequestSender::set_timer(
                                      tags);
   }
 
+  printf("\nreturn %ld\n", status);
   // Update the timer id. If the update to Chronos failed, that's OK,
   // don't reject the request or update the stored timer id.
   if (status == HTTP_OK)

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -456,7 +456,6 @@ Store::Status S4::get_aor(const std::string& id,
                           AoR** aor,
                           SAS::TrailId trail)
 {
-  printf("\ngetting\n");
   Store::Status rc;
 
   *aor = _aor_store->get_aor_data(id, trail);
@@ -494,7 +493,6 @@ Store::Status S4::write_aor(const std::string& id,
   // Send any Chronos timer requests
   if (_chronos_timer_request_sender->_chronos_conn && !_remote_s4s.empty())
   {
-    printf("\nsending\n");
     _chronos_timer_request_sender->send_timers(id, &aor, now, trail);
   }
 
@@ -592,7 +590,6 @@ void S4::ChronosTimerRequestSender::set_timer(
   // Otherwise sent a POST.
   if (timer_id == "")
   {
-    printf("\n\nempty post\n\n");
     status = _chronos_conn->send_post(temp_timer_id,
                                       expiry,
                                       callback_uri,
@@ -602,7 +599,6 @@ void S4::ChronosTimerRequestSender::set_timer(
   }
   else
   {
-    printf("put ID %s", timer_id.c_str());
     temp_timer_id = timer_id;
     status = _chronos_conn->send_put(temp_timer_id,
                                      expiry,
@@ -612,7 +608,6 @@ void S4::ChronosTimerRequestSender::set_timer(
                                      tags);
   }
 
-  printf("\nreturn %ld\n", status);
   // Update the timer id. If the update to Chronos failed, that's OK,
   // don't reject the request or update the stored timer id.
   if (status == HTTP_OK)

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -31,19 +31,16 @@
 #include "astaire_aor_store.h"
 
 // SDM-REFACTOR-TODO:
-// 1. Commonise logic in the handles? Or at least make more similar.
-// 2. TRC statements
-// 3. SAS logging (poss already covered by memcached logs)
-// 4. Lifetimes of AoRs?
 // 5. Implement PATCH
 // 6. Implement PATCH/PUT conversion, and protect against loops
-// 7. Implement max_expiry
 // 8. Full UT
 
 S4::S4(std::string id,
+       std::string callback_uri,
        AoRStore* aor_store,
        std::vector<S4*> remote_s4s) :
   _id(id),
+  _chronos_callback_uri(callback_uri),
   _aor_store(aor_store),
   _remote_s4s(remote_s4s)
 {
@@ -53,34 +50,44 @@ S4::~S4()
 {
 }
 
-HTTPCode S4::handle_get(std::string aor_id,
+HTTPCode S4::handle_get(const std::string& id,
                         AoR** aor,
                         uint64_t& version,
                         SAS::TrailId trail)
 {
+  TRC_DEBUG("Handling GET for %s on %s", id.c_str(), _id.c_str());
+
   HTTPCode rc;
   bool retry_get = true;
 
   while (retry_get == true)
   {
+    // Delete the AoR on each iteration, and set the retry flag to false.
+    // The flag is only set to true if there's data contention on the write.
+    delete *aor; *aor = NULL;
     retry_get = false;
-    Store::Status store_rc = get_aor(aor_id, aor, trail);
+
+    Store::Status store_rc = get_aor(id, aor, trail);
 
     if (store_rc == Store::Status::ERROR)
     {
+      TRC_DEBUG("Store error when getting subscriber %s on %s",
+                id.c_str(), _id.c_str());
       rc = HTTP_SERVER_ERROR;
     }
     else if (store_rc == Store::Status::NOT_FOUND)
     {
+      TRC_DEBUG("Subscriber not found when getting subscriber %s on %s",
+                id.c_str(), _id.c_str());
+
       // If we don't have any bindings, try the remote stores.
       rc = HTTP_NOT_FOUND;
 
       for (S4* remote_s4 : _remote_s4s)
       {
-        TRC_DEBUG("Handling remote GET on %s", remote_s4->get_id().c_str());
         AoR* remote_aor = NULL;
         uint64_t unused_version;
-        HTTPCode remote_rc = remote_s4->handle_get(aor_id,
+        HTTPCode remote_rc = remote_s4->handle_get(id,
                                                    &remote_aor,
                                                    unused_version,
                                                    trail);
@@ -91,22 +98,27 @@ HTTPCode S4::handle_get(std::string aor_id,
           // copy the information across.
           remote_aor->_cas = 0;
 
-          Store::Status store_rc = write_aor(aor_id, remote_aor, trail);
+          Store::Status store_rc = write_aor(id, *remote_aor, trail);
 
           if (store_rc == Store::Status::ERROR)
           {
-            // We haven't been able to write the data back to memcached.
+            TRC_DEBUG("Store error when adding subscriber %s to %s",
+                      id.c_str(), _id.c_str());
             delete remote_aor; remote_aor = NULL;
             rc = HTTP_SERVER_ERROR;
           }
           else if (store_rc == Store::Status::OK)
           {
+            TRC_DEBUG("Successfully added the subscriber %s to %s",
+                      id.c_str(), _id.c_str());
             version = remote_aor->_cas;
             *aor = remote_aor;
             rc = HTTP_OK;
           }
           else if (store_rc == Store::Status::DATA_CONTENTION)
           {
+            TRC_DEBUG("Contention when adding subscriber %s to %s",
+                      id.c_str(), _id.c_str());
             delete remote_aor; remote_aor = NULL;
             retry_get = true;
           }
@@ -117,6 +129,8 @@ HTTPCode S4::handle_get(std::string aor_id,
     }
     else
     {
+      TRC_DEBUG("Successfully retrieved subscriber %s from %s",
+                 id.c_str(), _id.c_str());
       version = (*aor)->_cas;
       rc = HTTP_OK;
     }
@@ -125,24 +139,28 @@ HTTPCode S4::handle_get(std::string aor_id,
   return rc;
 }
 
-HTTPCode S4::handle_local_delete(std::string aor_id,
-                                 uint64_t version,
-                                 SAS::TrailId trail)
+HTTPCode S4::handle_delete(const std::string& id,
+                           uint64_t version,
+                           SAS::TrailId trail)
 {
-  TRC_DEBUG("Handling local DELETE for %s on %s", aor_id.c_str(), _id.c_str());
+  TRC_DEBUG("Handling local DELETE for %s on %s", id.c_str(), _id.c_str());
 
   // Get the AoR from the data store - this only looks in the local store.
   AoR* aor = NULL;
-  Store::Status store_rc = get_aor(aor_id, &aor, trail);
+  Store::Status store_rc = get_aor(id, &aor, trail);
 
   HTTPCode rc;
 
   if (store_rc == Store::Status::ERROR)
   {
+    TRC_DEBUG("Store error when getting subscriber %s on %s during a DELETE",
+              id.c_str(), _id.c_str());
     rc = HTTP_SERVER_ERROR;
   }
   else if (store_rc == Store::Status::NOT_FOUND)
   {
+    TRC_DEBUG("Subscriber %s isn't on %s, unable to delete it",
+              id.c_str(), _id.c_str());
     rc = HTTP_PRECONDITION_FAILED;
   }
   else
@@ -153,28 +171,39 @@ HTTPCode S4::handle_local_delete(std::string aor_id,
       aor->clear(true);
 
       // Write the empty AoR back to the store.
-      Store::Status store_rc = write_aor(aor_id, aor, trail);
+      Store::Status store_rc = write_aor(id, *aor, trail);
 
       if (store_rc == Store::Status::OK)
       {
+        TRC_DEBUG("Successfully deleted subscriber %s from %s",
+                   id.c_str(), _id.c_str());
         rc = HTTP_NO_CONTENT;
 
         // Subscriber has been deleted from the local site, so send the DELETE
         // out to the remote sites. The response to the SM is always going to be
         // OK independently of whether any remote DELETEs are successful.
-        replicate_delete_cross_site(aor_id, trail);
+        replicate_delete_cross_site(id, trail);
       }
       else if (store_rc == Store::Status::DATA_CONTENTION)
       {
+        TRC_DEBUG("Contention when deleting subscriber %s from %s",
+                  id.c_str(), _id.c_str());
         rc = HTTP_PRECONDITION_FAILED;
       }
       else
       {
+        TRC_DEBUG("Store error when deleting subscriber %s from %s",
+                  id.c_str(), _id.c_str());
         rc = HTTP_SERVER_ERROR;
       }
     }
     else
     {
+      // The version isn't current. This suggests that the client is attempting
+      // to delete the subscriber without knowing the up to date information.
+      // Reject this.
+      TRC_DEBUG("Mismatched version. Delete version (%d), stored version (%d)",
+                version, aor->_cas);
       rc = HTTP_PRECONDITION_FAILED;
     }
   }
@@ -183,28 +212,32 @@ HTTPCode S4::handle_local_delete(std::string aor_id,
   return rc;
 }
 
-HTTPCode S4::handle_remote_delete(std::string aor_id,
-                                  SAS::TrailId trail)
+void S4::handle_remote_delete(const std::string& id,
+                              SAS::TrailId trail)
 {
-  TRC_DEBUG("Handling local DELETE for %s on %s", aor_id.c_str(), _id.c_str());
+  TRC_DEBUG("Handling DELETE for %s on %s", id.c_str(), _id.c_str());
 
   // Get the AoR from the data store - this only looks in the local store.
-  AoR* aor = NULL;
+  bool retry_delete = true;
 
-  HTTPCode rc;
-
-  do
+  while (retry_delete)
   {
-    delete aor; aor = NULL;
-    Store::Status store_rc = get_aor(aor_id, &aor, trail);
+    // Set the retry flag to false. The flag is only set to true if there's
+    // data contention on the write.
+    retry_delete = false;
+
+    AoR* aor = NULL;
+    Store::Status store_rc = get_aor(id, &aor, trail);
 
     if (store_rc == Store::Status::ERROR)
     {
-      rc = HTTP_SERVER_ERROR;
+      TRC_DEBUG("Store error when getting subscriber %s on %s during a DELETE",
+                 id.c_str(), _id.c_str());
     }
     else if (store_rc == Store::Status::NOT_FOUND)
     {
-      rc = HTTP_NOT_FOUND;
+      TRC_DEBUG("Subscriber %s isn't on %s, no need to delete it",
+                 id.c_str(), _id.c_str());
     }
     else
     {
@@ -212,130 +245,137 @@ HTTPCode S4::handle_remote_delete(std::string aor_id,
       aor->clear(true);
 
       // Write the empty AoR back to the store.
-      Store::Status store_rc = write_aor(aor_id, aor, trail);
+      Store::Status store_rc = write_aor(id, *aor, trail);
 
       if (store_rc == Store::Status::OK)
       {
-        rc = HTTP_OK;
+        TRC_DEBUG("Successfully deleted subscriber %s from %s",
+                   id.c_str(), _id.c_str());
       }
       else if (store_rc == Store::Status::DATA_CONTENTION)
       {
-        rc = HTTP_PRECONDITION_FAILED;
+        TRC_DEBUG("Contention when deleting subscriber %s from %s",
+                  id.c_str(), _id.c_str());
+        retry_delete = true;
       }
       else
       {
-        rc = HTTP_SERVER_ERROR;
+        TRC_DEBUG("Store error when deleting subscriber %s from %s",
+                  id.c_str(), _id.c_str());
       }
     }
-  }
-  while (rc == HTTP_PRECONDITION_FAILED);
 
-  delete aor; aor = NULL;
-  return rc;
+    delete aor; aor = NULL;
+  }
 }
 
-HTTPCode S4::handle_put(std::string aor_id,
-                        AoR* new_aor,
+HTTPCode S4::handle_put(const std::string& id,
+                        const AoR& aor,
                         SAS::TrailId trail)
 {
+  TRC_DEBUG("Adding subscriber %s to %s", id.c_str(), _id.c_str());
+
   HTTPCode rc = HTTP_OK;
 
-  // Get the AoR from the data store - this only looks in the local store.
-  AoR* aor = NULL;
-  Store::Status store_rc = get_aor(aor_id, &aor, trail);
+  // Attempt to write the data to the local store. We don't do a get first as
+  // we expect the subscriber shouldn't exist. If the subscriber already
+  // exists this will fail with data contention, and we'll return an error code
+  Store::Status store_rc = write_aor(id, (AoR&)aor, trail);
 
-  if (store_rc == Store::Status::ERROR)
+  if (store_rc == Store::Status::OK)
   {
-    rc = HTTP_SERVER_ERROR;
-  }
-  else if (store_rc == Store::Status::OK)
-  {
-    rc = HTTP_PRECONDITION_FAILED;
+    TRC_DEBUG("Successfully added subscriber %s to %s",
+              id.c_str(), _id.c_str());
+    rc = HTTP_OK;
+
+    // Subscriber has been added on the local site, so send the PUTs
+    // out to the remote sites. The response to the SM is always going to be
+    // OK independently of whether any remote PUTs are successful.
+    replicate_put_cross_site(id, aor, trail);
   }
   else
   {
-    new_aor->_cas = 0;
-
-    Store::Status store_rc = write_aor(aor_id, new_aor, trail);
-
-    if (store_rc == Store::Status::OK)
-    {
-      replicate_put_cross_site(aor_id, new_aor, trail);
-      rc = HTTP_OK;
-    }
-    else if (store_rc == Store::Status::ERROR)
-    {
-      // Failed to add data - we don't try and add the subscriber to
-      // any remote sites.
-      TRC_DEBUG("Failed to add subscriber %s to %s",
-                aor_id.c_str(),
-                _id.c_str());
-      rc = HTTP_SERVER_ERROR;
-    }
-    else if (store_rc == Store::Status::DATA_CONTENTION)
-    {
-      // Failed to add data - we don't try and add the subscriber to
-      // any remote sites.
-      TRC_DEBUG("Failed to add subscriber %s to %s",
-                aor_id.c_str(),
-                _id.c_str());
-      rc = HTTP_PRECONDITION_FAILED;
-    }
-  }
-
-  delete aor; aor = NULL;
-  return rc;
-}
-
-HTTPCode S4::handle_patch(std::string aor_id,
-                          PatchObject* po,
-                          AoR** aor,
-                          SAS::TrailId trail)
-{
-  HTTPCode rc = HTTP_OK;
-  bool retry_patch = true;
-
-  while (retry_patch)
-  {
-    retry_patch = false;
-
-    delete *aor; *aor = NULL;
-    Store::Status store_rc = get_aor(aor_id, aor, trail);
+    // Failed to add data - we don't try and add the subscriber to any remote
+    // sites.
+    TRC_DEBUG("Failed to add subscriber %s to %s", id.c_str(), _id.c_str());
 
     if (store_rc == Store::Status::ERROR)
     {
       rc = HTTP_SERVER_ERROR;
     }
+    else if (store_rc == Store::Status::DATA_CONTENTION)
+    {
+      rc = HTTP_PRECONDITION_FAILED;
+    }
+  }
+
+  return rc;
+}
+
+HTTPCode S4::handle_patch(const std::string& id,
+                          const PatchObject& po,
+                          AoR** aor,
+                          SAS::TrailId trail)
+{
+  TRC_DEBUG("Updating subscriber %s on %s", id.c_str(), _id.c_str());
+
+  HTTPCode rc = HTTP_OK;
+  bool retry_patch = true;
+
+  while (retry_patch)
+  {
+    // Delete the AoR on each iteration, and set the retry flag to false.
+    // The flag is only set to true if there's data contention on the write.
+    retry_patch = false;
+    delete *aor; *aor = NULL;
+
+    Store::Status store_rc = get_aor(id, aor, trail);
+
+    if (store_rc == Store::Status::ERROR)
+    {
+      TRC_DEBUG("Store error when getting subscriber %s on %s during a PATCH",
+                 id.c_str(), _id.c_str());
+      rc = HTTP_SERVER_ERROR;
+    }
     else if (store_rc == Store::Status::NOT_FOUND)
     {
+      // The subscriber can't be found - it's not valid to PATCH a non-existent
+      // subscriber.
+      TRC_DEBUG("Subscriber %s not found on %s during a PATCH",
+                 id.c_str(), _id.c_str());
       rc = HTTP_PRECONDITION_FAILED;
     }
     else
     {
       // Update the AoR with the requested changes.
       (*aor)->patch_aor(po);
-      Store::Status store_rc = write_aor(aor_id, *aor, trail);
+      Store::Status store_rc = write_aor(id, *(*aor), trail);
 
       if (store_rc == Store::Status::OK)
       {
-        replicate_patch_cross_site(aor_id, po, trail);
+        TRC_DEBUG("Updated subscriber %s on %s", id.c_str(), _id.c_str());
         rc = HTTP_OK;
+
+        // Subscriber has been updated on the local site, so send the PATCHs
+        // out to the remote sites. The response to the SM is always going to be
+        // OK independently of whether any remote PATCHs are successful.
+        replicate_patch_cross_site(id, po, trail);
       }
       else if (store_rc == Store::Status::DATA_CONTENTION)
       {
-        // Failed to updateadd data - we don't try and update the subscriber in
-        // any remote sites.
-        TRC_DEBUG("Failed to update subscriber %s to %s",
-                  aor_id.c_str(),
+        // Failed to update the subscriber due to data contention. Retry the
+        // update.
+        TRC_DEBUG("Failed to update subscriber %s on %s due to contention",
+                  id.c_str(),
                   _id.c_str());
         retry_patch = true;
       }
       else
       {
-        // Failed to updateadd data - we don't try and update the subscriber in
-        // any remote sites.
-        TRC_DEBUG("Failed to update subscriber %s to %s",
-                  aor_id.c_str(),
+        // Failed to update the subscriber due to a store error. There's no
+        // point in retrying. Delete the retrieved AoR to clean it up.
+        TRC_DEBUG("Failed to update subscriber %s on %s due to a store error",
+                  id.c_str(),
                   _id.c_str());
         delete *aor; *aor = NULL;
         rc = HTTP_SERVER_ERROR;
@@ -346,25 +386,26 @@ HTTPCode S4::handle_patch(std::string aor_id,
   return rc;
 }
 
-void S4::replicate_delete_cross_site(std::string aor_id,
+void S4::replicate_delete_cross_site(const std::string& id,
                                      SAS::TrailId trail)
 {
   for (S4* remote_s4 : _remote_s4s)
   {
-    remote_s4->handle_remote_delete(aor_id, trail);
+    remote_s4->handle_remote_delete(id, trail);
   }
 }
 
-void S4::replicate_put_cross_site(std::string aor_id,
-                                  AoR* aor,
+void S4::replicate_put_cross_site(const std::string& id,
+                                  const AoR& aor,
                                   SAS::TrailId trail)
 {
   for (S4* remote_s4 : _remote_s4s)
   {
-    HTTPCode rc = remote_s4->handle_put(aor_id, aor, trail);
+    HTTPCode rc = remote_s4->handle_put(id, aor, trail);
 
     if (rc == HTTP_PRECONDITION_FAILED)
     {
+     /* SDM-REFACTOR-TODO FLIP
       // We've tried to do a PUT to a remote site that already has data. We need
       // to send a PATCH instead.
       TRC_DEBUG("Need to convert PUT to PATCH for %s", _id.c_str());
@@ -373,83 +414,91 @@ void S4::replicate_put_cross_site(std::string aor_id,
       aor->convert_aor_to_patch(po);
       AoR* remote_aor = NULL;
 
-      remote_s4->handle_patch(aor_id, po, &remote_aor, trail);
+      remote_s4->handle_patch(id, po, &remote_aor, trail);
 
       delete po; po = NULL;
       delete remote_aor; remote_aor = NULL;
+      */
     }
   }
 }
 
-void S4::replicate_patch_cross_site(std::string aor_id,
-                                    PatchObject* po,
+void S4::replicate_patch_cross_site(const std::string& id,
+                                    const PatchObject& po,
                                     SAS::TrailId trail)
 {
   for (S4* remote_s4 : _remote_s4s)
   {
     AoR* remote_aor = NULL;
-    HTTPCode rc = remote_s4->handle_patch(aor_id, po, &remote_aor, trail);
+    HTTPCode rc = remote_s4->handle_patch(id, po, &remote_aor, trail);
     delete remote_aor; remote_aor = NULL;
 
     if (rc == HTTP_PRECONDITION_FAILED)
     {
+     /* SDM-REFACTOR-TODO FLIP
       // We've tried to do a PATCH to a remote site that doesn't have any data.
       // We need to send a PUT.
       TRC_DEBUG("Need to convert PATCH to PUT for %s", _id.c_str());
-      AoR* aor = new AoR(aor_id);
+      AoR* aor = new AoR(id);
       aor->convert_patch_to_aor(po);
-      remote_s4->handle_put(aor_id, aor, trail);
+      remote_s4->handle_put(id, aor, trail);
       delete aor; aor = NULL;
+     */
     }
   }
 }
 
-Store::Status S4::get_aor(const std::string& aor_id,
+Store::Status S4::get_aor(const std::string& id,
                           AoR** aor,
                           SAS::TrailId trail)
 {
   Store::Status rc;
 
-  *aor = _aor_store->get_aor_data(aor_id, trail);
+  *aor = _aor_store->get_aor_data(id, trail);
 
   if (aor == NULL || *aor == NULL)
   {
-    // Store error when getting data.
+    // Store error when getting data - return an error.
     TRC_DEBUG("Store error when getting the AoR for %s from %s",
-               aor_id.c_str(), _id.c_str());
+               id.c_str(), _id.c_str());
     rc = Store::Status::ERROR;
   }
   else if ((*aor)->bindings().empty())
   {
     // We successfully contacted the store, but we didn't find the AoR. This
     // creates an empty AoR - delete this and return not found.
-    TRC_DEBUG("No AoR found for %s from %s", aor_id.c_str(), _id.c_str());
+    TRC_DEBUG("No AoR found for %s from %s", id.c_str(), _id.c_str());
     rc = Store::Status::NOT_FOUND;
     delete *aor; *aor = NULL;
   }
   else
   {
-    TRC_DEBUG("Found an AoR for %s from %s", aor_id.c_str(), _id.c_str());
+    TRC_DEBUG("Found an AoR for %s from %s", id.c_str(), _id.c_str());
     rc = Store::Status::OK;
   }
 
   return rc;
 }
 
-Store::Status S4::write_aor(const std::string& aor_id,
-                            AoR* aor,
+Store::Status S4::write_aor(const std::string& id,
+                            AoR& aor,
                             SAS::TrailId trail)
 {
-  int next_expires;
-  int last_expires;
-  int now = time(NULL);
-  aor->get_next_and_last_expires(next_expires, last_expires);
+  // SDM-REFACTOR-TODO: Set Chronos Timers
+  Store::Status rc = _aor_store->set_aor_data(id,
+                                              &aor,
+                                              aor.get_last_expires() + 10,
+                                              trail);
+  if (rc == Store::Status::OK)
+  {
+    TRC_DEBUG("Successfully written AoR for %s to %s",
+              id.c_str(), _id.c_str());
+  }
+  else
+  {
+    TRC_DEBUG("Failed to write AoR for %s to %s",
+              id.c_str(), _id.c_str());
+  }
 
-  TRC_DEBUG("Expires are %d, %d: Now is %d", next_expires, last_expires, now);
-  // SDM-REFACTOR-TODO: Set Chronos timer.
-
-  return _aor_store->set_aor_data(aor_id,
-                                  aor,
-                                  last_expires + 10,
-                                  trail);
+  return rc;
 }

--- a/src/ut/mock_s4.cpp
+++ b/src/ut/mock_s4.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file mock_s4.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+
+#include "mock_s4.h"
+
+MockS4::MockS4():
+  S4("", NULL, std::vector<S4*>())
+{}
+
+MockS4::~MockS4()
+{}

--- a/src/ut/mock_s4.cpp
+++ b/src/ut/mock_s4.cpp
@@ -13,7 +13,7 @@
 #include "mock_s4.h"
 
 MockS4::MockS4():
-  S4("", NULL, std::vector<S4*>())
+  S4("mock_id", "mock_callback", NULL, std::vector<S4*>())
 {}
 
 MockS4::~MockS4()

--- a/src/ut/mock_s4.cpp
+++ b/src/ut/mock_s4.cpp
@@ -13,7 +13,7 @@
 #include "mock_s4.h"
 
 MockS4::MockS4():
-  S4("mock_id", "mock_callback", NULL, std::vector<S4*>())
+  S4("mock_id", NULL, "mock_callback", NULL, std::vector<S4*>())
 {}
 
 MockS4::~MockS4()

--- a/src/ut/mock_s4.cpp
+++ b/src/ut/mock_s4.cpp
@@ -13,7 +13,7 @@
 #include "mock_s4.h"
 
 MockS4::MockS4():
-  S4("", NULL, std::vector<S4*>())
+  S4("", NULL, NULL, std::vector<S4*>())
 {}
 
 MockS4::~MockS4()

--- a/src/ut/mock_s4.h
+++ b/src/ut/mock_s4.h
@@ -21,24 +21,21 @@ class MockS4 : public S4
   MockS4();
   virtual ~MockS4();
 
-  MOCK_METHOD4(handle_get, HTTPCode(std::string aor_id,
+  MOCK_METHOD4(handle_get, HTTPCode(const std::string& id,
                                     AoR** aor,
                                     uint64_t& version,
                                     SAS::TrailId trail));
 
-  MOCK_METHOD3(handle_local_delete, HTTPCode(std::string aor_id,
-                                             uint64_t cas,
-                                             SAS::TrailId trail));
+  MOCK_METHOD3(handle_delete, HTTPCode(const std::string& id,
+                                       uint64_t version,
+                                       SAS::TrailId trail));
 
-  MOCK_METHOD2(handle_remote_delete, HTTPCode(std::string aor_id,
-                                              SAS::TrailId trail));
+  MOCK_METHOD3(handle_put, HTTPCode(const std::string& id,
+                                    const AoR& aor,
+                                    SAS::TrailId trail));
 
-  MOCK_METHOD3(handle_put, HTTPCode(std::string aor_id,
-                                    AoR* aor,
-                                    SAS::TrailId id));
-
-  MOCK_METHOD4(handle_patch, HTTPCode(std::string aor_id,
-                                      PatchObject* patch_object,
+  MOCK_METHOD4(handle_patch, HTTPCode(const std::string& id,
+                                      const PatchObject& patch_object,
                                       AoR** aor,
                                       SAS::TrailId trail));
 };

--- a/src/ut/mock_s4.h
+++ b/src/ut/mock_s4.h
@@ -1,0 +1,40 @@
+/**
+ * @file mock_s4.h
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef MOCK_S4_H__
+#define MOCK_S4_H__
+
+#include "gmock/gmock.h"
+#include "s4.h"
+
+
+class MockS4 : public S4
+{
+  MockS4();
+  virtual ~MockS4();
+
+  MOCK_METHOD3(handle_get, HTTPCode(std::string aor_id,
+                                    AoR** aor,
+                                    SAS::TrailId trail));
+
+  MOCK_METHOD2(handle_delete, HTTPCode(std::string aor_id,
+                                       SAS::TrailId trail));
+
+  MOCK_METHOD3(handle_put, HTTPCode(std::string aor_id,
+                                    AoR* aor,
+                                    SAS::TrailId id));
+
+  MOCK_METHOD3(handle_patch, HTTPCode(std::string aor_id,
+                                      PatchObject* patch_object,
+                                      SAS::TrailId trail));
+};
+
+#endif

--- a/src/ut/mock_s4.h
+++ b/src/ut/mock_s4.h
@@ -21,19 +21,25 @@ class MockS4 : public S4
   MockS4();
   virtual ~MockS4();
 
-  MOCK_METHOD3(handle_get, HTTPCode(std::string aor_id,
+  MOCK_METHOD4(handle_get, HTTPCode(std::string aor_id,
                                     AoR** aor,
+                                    uint64_t& version,
                                     SAS::TrailId trail));
 
-  MOCK_METHOD2(handle_delete, HTTPCode(std::string aor_id,
-                                       SAS::TrailId trail));
+  MOCK_METHOD3(handle_local_delete, HTTPCode(std::string aor_id,
+                                             uint64_t cas,
+                                             SAS::TrailId trail));
+
+  MOCK_METHOD2(handle_remote_delete, HTTPCode(std::string aor_id,
+                                              SAS::TrailId trail));
 
   MOCK_METHOD3(handle_put, HTTPCode(std::string aor_id,
                                     AoR* aor,
                                     SAS::TrailId id));
 
-  MOCK_METHOD3(handle_patch, HTTPCode(std::string aor_id,
+  MOCK_METHOD4(handle_patch, HTTPCode(std::string aor_id,
                                       PatchObject* patch_object,
+                                      AoR** aor,
                                       SAS::TrailId trail));
 };
 


### PR DESCRIPTION
Graeme - can you please review these changes to add S4?

There are no changes to the aor_store.*, astaire_aor_store.* or associated_uris.* files - they've just been moved to this module as the S4 code depends on them.

The s4* files want to be completely reviewed. This includes the change to set Chronos timers when writing data to the store. There's one change that's missing from this, which is plumbing through the callback_uri from the constructor to setting the timers, but that shouldn't hold up this review.

The aor.* files need partial reviewing. The changes are:
* The Binding and Subscription classes have moved out from the AoR class (along with the useful typedefs Bindings/BindingPair/Subscriptions/SubscriptionPair)
* The AoR class has two new functions - get_last_expires and patch_aor
* There's a new PatchObject class
* There's a new function convert_aor_to_patch.
* Once the work is complete, the AoRPair class will be removed, but that can't be done yet.

I'm intending to rename the PatchObject class, and the handle_* methods in S4 (but I'm not sure what to yet - suggestions welcome).