### PR TITLE
[Reviewer: Sathiyan] Don't always clear the AUs

### DIFF
--- a/include/aor.h
+++ b/include/aor.h
@@ -298,7 +298,7 @@ public:
   void common_constructor(const AoR& other);
 
   /// Clear all the bindings and subscriptions from this object.
-  void clear();
+  void clear(bool clear_associated_uris);
 
   /// Retrieve a binding by Binding ID, creating an empty one if necessary.
   /// The created binding is completely empty, even the Contact URI field.

--- a/src/aor.cpp
+++ b/src/aor.cpp
@@ -32,7 +32,7 @@ AoR::AoR(std::string sip_uri) :
 /// Destructor.
 AoR::~AoR()
 {
-  clear();
+  clear(true);
 }
 
 
@@ -48,7 +48,7 @@ AoR& AoR::operator= (AoR const& other)
 {
   if (this != &other)
   {
-    clear();
+    clear(true);
     common_constructor(other);
   }
 
@@ -142,7 +142,7 @@ void AoR::common_constructor(const AoR& other)
 // LCOV_EXCL_STOP
 
 /// Clear all the bindings and subscriptions from this object.
-void AoR::clear()
+void AoR::clear(bool remove_associated_uris)
 {
   for (BindingPair binding : _bindings)
   {
@@ -156,9 +156,12 @@ void AoR::clear()
 
   _bindings.clear();
   _subscriptions.clear();
-  _associated_uris.clear_uris();
-}
 
+  if (remove_associated_uris)
+  {
+    _associated_uris.clear_uris();
+  }
+}
 
 /// Retrieve a binding by binding identifier, creating an empty one if
 /// necessary.  The created binding is completely empty, even the Contact URI

--- a/src/s4.cpp
+++ b/src/s4.cpp
@@ -172,7 +172,7 @@ HTTPCode S4::handle_delete(const std::string& sub_id,
     if (aor->_cas == version)
     {
       // Clear the AoR.
-      aor->clear();
+      aor->clear(false);
 
       // Write the empty AoR back to the store.
       Store::Status store_rc = write_aor(sub_id, *aor, trail);
@@ -246,7 +246,7 @@ void S4::handle_remote_delete(const std::string& sub_id,
     else
     {
       // Clear the AoR.
-      aor->clear();
+      aor->clear(false);
 
       // Write the empty AoR back to the store.
       Store::Status store_rc = write_aor(sub_id, *aor, trail);
@@ -516,7 +516,7 @@ Store::Status S4::write_aor(const std::string& sub_id,
   if (aor.bindings().empty() && !aor.subscriptions().empty())
   {
     TRC_DEBUG("Cleaning up AoR");
-    aor.clear();
+    aor.clear(false);
   }
 
   // If the AoR has only emergency bindings, then we should remove any


### PR DESCRIPTION
We don't want to remove the Associated URIs when we remove the bindings; only do this on AoR destruction.